### PR TITLE
Update to fix crashing when installing modules

### DIFF
--- a/pts-core/objects/client/display_modes/pts_websocket_display_mode.php
+++ b/pts-core/objects/client/display_modes/pts_websocket_display_mode.php
@@ -193,7 +193,8 @@ class pts_websocket_display_mode implements pts_display_mode_interface
 	}
 	public function test_install_start($identifier)
 	{
-		$this->update_install_status(null, null);
+		$null_ref_var = null;
+		$this->update_install_status($null_ref_var, null);
 	}
 	public function test_install_downloads($test_install_request)
 	{
@@ -203,8 +204,8 @@ class pts_websocket_display_mode implements pts_display_mode_interface
 		{
 			$stats['test_download_time'] = ($size * 1048576) / $avg_speed;
 		}
-
-		$this->update_install_status(null, $test_install_request, $stats);
+		$null_ref_var = null;
+		$this->update_install_status($null_ref_var, $test_install_request, $stats);
 	}
 	public function test_install_download_file($process, &$pts_test_file_download)
 	{


### PR DESCRIPTION
The webui client was crashing when installing a new module with: 
"PHP Fatal error:  Cannot pass parameter 1 by reference in /usr/share/phoronix-test-suite/pts-core/objects/client/display_modes/pts_websocket_display_mode.php on line 196"
This is because update_install_status was trying to pass the reference of 'null', and PHP hates that.
I have updated it to create a temp variable set to 'null' and then pass that in.
