### PR TITLE
Setting socket_select to 'null' instead of '0' boosts performance tremendously.

### DIFF
--- a/pts-core/objects/pts_web_socket.php
+++ b/pts-core/objects/pts_web_socket.php
@@ -61,7 +61,7 @@ class pts_web_socket
 			$changed = $this->sockets;
 			$write = null;
 			$except = null;
-			socket_select($changed, $write, $except, 0);
+			socket_select($changed, $write, $except, null);
 
 			foreach($changed as $socket)
 			{


### PR DESCRIPTION
For Web-socket Server:
This is a simple fix for a MAJOR performance issue. the websocket server will spin on the main while loop while waiting for the socket to be written to, and that will chew up 100% of the CPU. This makes socket_select block indefinitely.
