### PR TITLE
Fix SuperLU missing dependency issues on Fedora

### DIFF
--- a/pts-core/external-test-dependencies/xml/fedora-packages.xml
+++ b/pts-core/external-test-dependencies/xml/fedora-packages.xml
@@ -236,7 +236,7 @@
 		</Package>
 		<Package>
 			<GenericName>superlu</GenericName>
-			<PackageName>superlu libsuperlu3</PackageName>
+			<PackageName>superlu-devel</PackageName>
 		</Package>
 		<Package>
 			<GenericName>suitesparse</GenericName>

--- a/pts-core/external-test-dependencies/xml/generic-packages.xml
+++ b/pts-core/external-test-dependencies/xml/generic-packages.xml
@@ -377,8 +377,8 @@
 		<Package>
 			<GenericName>superlu</GenericName>
 			<Title>SuperLU</Title>
-			<PossibleNames>superlu, libsuperlu3-dev</PossibleNames>
-			<FileCheck>superlu/slu_util.h</FileCheck>
+			<PossibleNames>superlu, libsuperlu3-dev, SuperLU-devel</PossibleNames>
+			<FileCheck>superlu/slu_util.h OR SuperLU/slu_util.h, libsuperlu.so</FileCheck>
 		</Package>
 		<Package>
 			<GenericName>suitesparse</GenericName>


### PR DESCRIPTION
``libsuperlu3`` is the Debian package name, it should be ``SuperLU-devel``, but
I made it lower case in order to better match the file's conventions.

The generic XML file also has issues with casing - on Fedora at least, the include directory is ``SuperLU`` and it won't detect a properly installed RPM.

I also added ``libsuperlu.so`` to the file checks - according to [rpm.pbone.net], that file name appears to be common across most distros.
