### PR TITLE
Added support for https in test-profile definitions URLs.

### DIFF
--- a/pts-core/openbenchmarking.org/schemas/types.xsd
+++ b/pts-core/openbenchmarking.org/schemas/types.xsd
@@ -137,6 +137,7 @@
 <xs:simpleType name="URLString">
 	<xs:restriction base="xs:string">
 		<xs:pattern value="http://.*" />
+		<xs:pattern value="https://.*" />
 		<xs:minLength value="12" />
 	</xs:restriction>
 </xs:simpleType>


### PR DESCRIPTION
Using "https" in a test-profile definition would abort with the error:

```
Errors occurred parsing the main XML.

Element 'ProjectURL': [facet 'pattern'] The value 'https://github.com/StuntsPT/Structure_threader' is not accepted by the pattern 'http://.*'.
```

Instead of changing my URLs to "http" I made this PR.