### PR TITLE
Made a distinction between python2 and python3.

### DIFF
--- a/pts-core/external-test-dependencies/xml/arch-packages.xml
+++ b/pts-core/external-test-dependencies/xml/arch-packages.xml
@@ -175,8 +175,12 @@
 			<PackageName>tcl</PackageName>
 		</Package>
 		<Package>
-			<GenericName>python</GenericName>
+			<GenericName>python3</GenericName>
 			<PackageName>python</PackageName>
+		</Package>
+		<Package>
+			<GenericName>python2</GenericName>
+			<PackageName>python2</PackageName>
 		</Package>
 		<Package>
 			<GenericName>yasm</GenericName>

--- a/pts-core/external-test-dependencies/xml/generic-packages.xml
+++ b/pts-core/external-test-dependencies/xml/generic-packages.xml
@@ -315,10 +315,16 @@
 			<FileCheck>gnu/stubs-32.h OR gnu-versions.h, libc.a</FileCheck>
 		</Package>
 		<Package>
-			<GenericName>python</GenericName>
-			<Title>Python</Title>
-			<PossibleNames>python</PossibleNames>
-			<FileCheck>python</FileCheck>
+			<GenericName>python2</GenericName>
+			<Title>Python 2</Title>
+			<PossibleNames>python, python2</PossibleNames>
+			<FileCheck>python2</FileCheck>
+		</Package>
+		<Package>
+			<GenericName>python3</GenericName>
+			<Title>Python 3</Title>
+			<PossibleNames>python, python3</PossibleNames>
+			<FileCheck>python3</FileCheck>
 		</Package>
 		<Package>
 			<GenericName>python-boost-development</GenericName>
@@ -333,9 +339,15 @@
 			<FileCheck>boost/thread.hpp</FileCheck>
 		</Package>
 		<Package>
-			<GenericName>python-numpy</GenericName>
-			<Title>Python Numpy</Title>
-			<PossibleNames>python-numpy</PossibleNames>
+			<GenericName>python2-numpy</GenericName>
+			<Title>Python 2 Numpy</Title>
+			<PossibleNames>python-numpy, python2-numpy</PossibleNames>
+			<FileCheck>/usr/shared/pyshared/numpy/version.py</FileCheck>
+		</Package>
+		<Package>
+			<GenericName>python3-numpy</GenericName>
+			<Title>Python 3 Numpy</Title>
+			<PossibleNames>python-numpy, python3-numpy</PossibleNames>
 			<FileCheck>/usr/shared/pyshared/numpy/version.py</FileCheck>
 		</Package>
 		<Package>

--- a/pts-core/external-test-dependencies/xml/ubuntu-packages.xml
+++ b/pts-core/external-test-dependencies/xml/ubuntu-packages.xml
@@ -243,8 +243,12 @@
 			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
 		</Package>
 		<Package>
-			<GenericName>python</GenericName>
+			<GenericName>python2</GenericName>
 			<PackageName>python</PackageName>
+		</Package>
+		<Package>
+			<GenericName>python3</GenericName>
+			<PackageName>python3</PackageName>
 		</Package>
 		<Package>
 			<GenericName>python-boost-development</GenericName>
@@ -255,9 +259,14 @@
 			<PackageName>libboost-thread-dev</PackageName>
 		</Package>
 		<Package>
-			<GenericName>python-numpy</GenericName>
+			<GenericName>python2-numpy</GenericName>
 			<PackageName>python-numpy</PackageName>
-			<FileCheck>/usr/share/pyshared/numpy/version.py</FileCheck>
+			<FileCheck>/usr/share/doc/python-numpy/copyright</FileCheck>
+		</Package>
+		<Package>
+			<GenericName>python3-numpy</GenericName>
+			<PackageName>python3-numpy</PackageName>
+			<FileCheck>/usr/share/doc/python3-numpy/copyright</FileCheck>
 		</Package>
 		<Package>
 			<GenericName>yasm</GenericName>


### PR DESCRIPTION
I changed both the "generic" names and the ArchLinux and Ubuntu specific ones. I'm really not sure how it works on other distros.
This should come in handy for test profiles that use both python2 and python3.
I've also made some changes regarding numpy, because at least for Ubuntu, the filecheck is simply wrong nowadays (might have been right some time ago though).