### PR TITLE
Align phx_graph strokes with the pixel grid.

### DIFF
--- a/pts-core/objects/phx_graph/phx_graph_core.php
+++ b/pts-core/objects/phx_graph/phx_graph_core.php
@@ -533,7 +533,7 @@ abstract class phx_graph_core
 		// Background Color
 		if($this->i['iveland_view'] || self::$c['graph']['border'])
 		{
-			$this->svg_dom->add_element('rect', array('x' => 1, 'y' => 1, 'width' => ($this->i['graph_width'] - 2), 'height' => ($this->i['graph_height'] - 1), 'fill' => self::$c['color']['background'], 'stroke' => self::$c['color']['border'], 'stroke-width' => 1));
+			$this->svg_dom->add_element('rect', array('x' => 0, 'y' => 0, 'width' => $this->i['graph_width'], 'height' => $this->i['graph_height'], 'fill' => self::$c['color']['background'], 'stroke' => self::$c['color']['border'], 'stroke-width' => 2));
 		}
 		else
 		{
@@ -628,8 +628,8 @@ abstract class phx_graph_core
 	{
 		if($this->i['graph_orientation'] == 'HORIZONTAL' || $this->i['iveland_view'])
 		{
-			$this->svg_dom->draw_svg_line($left_start, $top_start, $left_start, $top_end, self::$c['color']['notches'], 1);
-			$this->svg_dom->draw_svg_line($left_start, $top_end, $left_end, $top_end, self::$c['color']['notches'], 1);
+			$this->svg_dom->draw_svg_line($left_start + 0.5, $top_start, $left_start + 0.5, $top_end + 1, self::$c['color']['notches'], 1);
+			$this->svg_dom->draw_svg_line($left_start, $top_end + 0.5, $left_end + 1, $top_end + 0.5, self::$c['color']['notches'], 1);
 
 			if(!empty(self::$c['text']['watermark']))
 			{
@@ -712,9 +712,9 @@ abstract class phx_graph_core
 
 				if($i != 0)
 				{
-					$show_numbers && $this->svg_dom->add_text_element($display_value, array('x' => $px_from_left, 'y' => ($top_end + 5 + self::$c['size']['tick_mark']), 'font-size' => self::$c['size']['tick_mark'], 'fill' => self::$c['color']['text'], 'text-anchor' => 'middle'));
-					$this->svg_dom->draw_svg_line($px_from_left + 2, $top_start, $px_from_left + 2, $top_end - 5, self::$c['color']['body'], 1, array('stroke-dasharray' => '5,5'));
-					$this->svg_dom->draw_svg_line($px_from_left + 2, $top_end - 4, $px_from_left + 2, $top_end + 4, self::$c['color']['notches'], 1);
+					$show_numbers && $this->svg_dom->add_text_element($display_value, array('x' => $px_from_left + 2.5, 'y' => ($top_end + 5 + self::$c['size']['tick_mark']), 'font-size' => self::$c['size']['tick_mark'], 'fill' => self::$c['color']['text'], 'text-anchor' => 'middle'));
+					$this->svg_dom->draw_svg_line($px_from_left + 2.5, $top_start, $px_from_left + 2.5, $top_end - 5, self::$c['color']['body'], 1, array('stroke-dasharray' => '5,5'));
+					$this->svg_dom->draw_svg_line($px_from_left + 2.5, $top_end - 4, $px_from_left + 2.5, $top_end + 5, self::$c['color']['notches'], 1);
 				}
 
 				$display_value += $increment;
@@ -735,15 +735,15 @@ abstract class phx_graph_core
 
 				if($i != 0)
 				{
-					$show_numbers && $this->svg_dom->add_text_element($display_value, array('x' => ($px_from_left_start - 4), 'y' => round($px_from_top + (self::$c['size']['tick_mark'] / 2)), 'font-size' => self::$c['size']['tick_mark'], 'fill' =>  self::$c['color']['text'], 'text-anchor' => 'end'));
+					$show_numbers && $this->svg_dom->add_text_element($display_value, array('x' => ($px_from_left_start - 4), 'y' => round($px_from_top + (self::$c['size']['tick_mark'] / 2)) + 0.5, 'font-size' => self::$c['size']['tick_mark'], 'fill' =>  self::$c['color']['text'], 'text-anchor' => 'end'));
 
 					if($this->i['show_background_lines'])
 					{
-						$this->svg_dom->draw_svg_line($px_from_left_end + 6, $px_from_top + 1, $this->i['graph_left_end'], $px_from_top + 1, self::$c['color']['body_light'], 1, array('stroke-dasharray' => '5,5'));
+						$this->svg_dom->draw_svg_line($px_from_left_end + 6, $px_from_top + 1.5, $this->i['graph_left_end'], $px_from_top + 1.5, self::$c['color']['body_light'], 1, array('stroke-dasharray' => '5,5'));
 					}
 
-					$this->svg_dom->draw_svg_line($left_start, $px_from_top + 1, $left_end, $px_from_top + 1, self::$c['color']['notches'], 1, array('stroke-dasharray' => '5,5'));
-					$this->svg_dom->draw_svg_line($left_start - 4, $px_from_top + 1, $left_start + 4, $px_from_top + 1, self::$c['color']['notches'], 1);
+					$this->svg_dom->draw_svg_line($left_start, $px_from_top + 1.5, $left_end, $px_from_top + 1.5, self::$c['color']['notches'], 1, array('stroke-dasharray' => '5,5'));
+					$this->svg_dom->draw_svg_line($left_start - 4, $px_from_top + 1.5, $left_start + 4, $px_from_top + 1.5, self::$c['color']['notches'], 1);
 				}
 
 				$display_value += $increment;
@@ -824,9 +824,9 @@ abstract class phx_graph_core
 			$arrow_length_half = $arrow_length / 2;
 
 			$arrow_points = array(
-				$tip_x1 . ',' . $tip_y1,
-				$tail_x1 . ',' . ($tail_y1 + $arrow_length_half),
-				$tail_x1 . ',' . ($tail_y1 - $arrow_length_half)
+				$tip_x1 + 0.5 . ',' . $tip_y1,
+				$tail_x1 + 0.5 . ',' . ($tail_y1 + $arrow_length_half),
+				$tail_x1 + 0.5. ',' . ($tail_y1 - $arrow_length_half)
 				);
 		}
 

--- a/pts-core/objects/phx_graph/phx_graph_horizontal_bars.php
+++ b/pts-core/objects/phx_graph/phx_graph_horizontal_bars.php
@@ -38,7 +38,7 @@ class phx_graph_horizontal_bars extends phx_graph_core
 	{
 		$px_from_top_end = $this->i['graph_top_end'] + 5;
 
-		$this->svg_dom->draw_svg_line($this->i['left_start'], $this->i['top_start'] + $this->i['identifier_height'], $this->i['left_start'], $this->i['graph_top_end'] - ($this->i['graph_height'] % $this->i['identifier_height']), self::$c['color']['notches'], 10, array('stroke-dasharray' => 1 . ',' . ($this->i['identifier_height'] - 1)));
+		$this->svg_dom->draw_svg_line($this->i['left_start'] + 0.5, $this->i['top_start'] + $this->i['identifier_height'], $this->i['left_start'] + 0.5, $this->i['graph_top_end'] - ($this->i['graph_height'] % $this->i['identifier_height']), self::$c['color']['notches'], 11, array('stroke-dasharray' => 1 . ',' . ($this->i['identifier_height'] - 1)));
 		$middle_of_vert = $this->i['top_start'] + ($this->is_multi_way_comparison ? 5 : 0) - ($this->i['identifier_height'] * 0.5) - 2;
 
 		foreach($this->graph_identifiers as $identifier)
@@ -133,7 +133,7 @@ class phx_graph_horizontal_bars extends phx_graph_core
 					}
 				}
 
-				$this->svg_dom->add_element('rect', array('x' => $this->i['left_start'], 'y' => $px_bound_top, 'width' => $graph_size, 'height' => $bar_height, 'fill' => (in_array($buffer_item->get_result_identifier(), $this->value_highlights) ? self::$c['color']['highlight'] : $paint_color), 'stroke' => self::$c['color']['body_light'], 'stroke-width' => 1, 'xlink:title' => $title_tooltip));
+				$this->svg_dom->add_element('rect', array('x' => $this->i['left_start'] + 0.5, 'y' => $px_bound_top + 0.5, 'width' => $graph_size, 'height' => $bar_height, 'fill' => (in_array($buffer_item->get_result_identifier(), $this->value_highlights) ? self::$c['color']['highlight'] : $paint_color), 'stroke' => self::$c['color']['body_light'], 'stroke-width' => 1, 'xlink:title' => $title_tooltip));
 
 				if($std_error != -1 && $value != null)
 				{
@@ -143,9 +143,11 @@ class phx_graph_horizontal_bars extends phx_graph_core
 						$std_error_rel_size = round(($std_error / $this->i['graph_max_value']) * ($this->i['graph_left_end'] - $this->i['left_start']));
 						if($std_error_rel_size > 4)
 						{
-							$this->svg_dom->draw_svg_line(($value_end_right - $std_error_rel_size), $px_bound_top, ($value_end_right - $std_error_rel_size), $px_bound_top + $std_error_height, self::$c['color']['notches'], 1);
-							$this->svg_dom->draw_svg_line(($value_end_right + $std_error_rel_size), $px_bound_top, ($value_end_right + $std_error_rel_size), $px_bound_top + $std_error_height, self::$c['color']['notches'], 1);
-							$this->svg_dom->draw_svg_line(($value_end_right - $std_error_rel_size), $px_bound_top, ($value_end_right + $std_error_rel_size), $px_bound_top, self::$c['color']['notches'], 1);
+							$std_error_base_left = ($value_end_right - $std_error_rel_size) + 0.5;
+							$std_error_base_right = ($value_end_right + $std_error_rel_size) + 0.5;
+							$this->svg_dom->draw_svg_line($std_error_base_left, $px_bound_top, $std_error_base_left, $px_bound_top + $std_error_height, self::$c['color']['notches'], 1);
+							$this->svg_dom->draw_svg_line($std_error_base_right, $px_bound_top, $std_error_base_right, $px_bound_top + $std_error_height, self::$c['color']['notches'], 1);
+							$this->svg_dom->draw_svg_line($std_error_base_left, $px_bound_top + 0.5, $std_error_base_right, $px_bound_top + 0.5, self::$c['color']['notches'], 1);
 						}
 					}
 					$bar_offset_34 = $middle_of_bar + ($this->is_multi_way_comparison ? 0 : ($bar_height / 5) + 1);
@@ -169,9 +171,6 @@ class phx_graph_horizontal_bars extends phx_graph_core
 				}
 			}
 		}
-
-		// write a new line along the bottom since the draw_rectangle_with_border above had written on top of it
-		$this->svg_dom->draw_svg_line($this->i['left_start'], $this->i['graph_top_end'], $this->i['graph_left_end'], $this->i['graph_top_end'], self::$c['color']['notches'], 1);
 	}
 	protected function render_graph_result()
 	{


### PR DESCRIPTION
if the stroke comes from a whole number, an odd-number-wide stroke will end half-way across a pixel boundary.

This PR adds a constant half-pixel offset to relevant elements so that their lines fill a single pixel width rather than half of two.