### PR TITLE
Add configuration option to print all test steps

### DIFF
--- a/pts-core/objects/client/pts_client.php
+++ b/pts-core/objects/client/pts_client.php
@@ -29,6 +29,7 @@ class pts_client
 	private static $forked_pids = array();
 	protected static $phoromatic_servers = array();
 	protected static $debug_mode = false;
+	protected static $full_output = false;
 
 	public static function create_lock($lock_file)
 	{

--- a/pts-core/objects/client/pts_test_execution.php
+++ b/pts-core/objects/client/pts_test_execution.php
@@ -39,6 +39,7 @@ class pts_test_execution
 		$test_identifier = $test_run_request->test_profile->get_identifier();
 		$extra_arguments = $test_run_request->get_arguments();
 		$arguments_description = $test_run_request->get_arguments_description();
+		$full_output = pts_config::read_bool_config('PhoronixTestSuite/Options/General/FullOutput', 'FALSE');
 
 		// Do the actual test running process
 		$test_directory = $test_run_request->test_profile->get_install_dir();
@@ -90,7 +91,7 @@ class pts_test_execution
 		{
 			$pre_output = pts_tests::call_test_script($test_run_request->test_profile, 'pre', 'Running Pre-Test Script', $pts_test_arguments, $extra_runtime_variables, true);
 
-			if($pre_output != null && pts_client::is_debug_mode())
+			if($pre_output != null && (pts_client::is_debug_mode() || $full_output))
 			{
 				pts_client::$display->test_run_instance_output($pre_output);
 			}
@@ -213,12 +214,12 @@ class pts_test_execution
 			}
 
 
-			if(!isset($test_result[10240]) || pts_client::is_debug_mode())
+			if(!isset($test_result[10240]) || pts_client::is_debug_mode() || $full_output)
 			{
 				pts_client::$display->test_run_instance_output($test_result);
 			}
 
-			if(is_file($test_log_file) && trim($test_result) == null && (filesize($test_log_file) < 10240 || pts_client::is_debug_mode()))
+			if(is_file($test_log_file) && trim($test_result) == null && (filesize($test_log_file) < 10240 || pts_client::is_debug_mode() || $full_output))
 			{
 				$test_log_file_contents = file_get_contents($test_log_file);
 				pts_client::$display->test_run_instance_output($test_log_file_contents);
@@ -350,7 +351,7 @@ class pts_test_execution
 				{
 					$interim_output = pts_tests::call_test_script($test_run_request->test_profile, 'interim', 'Running Interim Test Script', $pts_test_arguments, $extra_runtime_variables, true);
 
-					if($interim_output != null && pts_client::is_debug_mode())
+					if($interim_output != null && (pts_client::is_debug_mode() || $full_output))
 					{
 						pts_client::$display->test_run_instance_output($interim_output);
 					}
@@ -395,7 +396,7 @@ class pts_test_execution
 		{
 			$post_output = pts_tests::call_test_script($test_run_request->test_profile, 'post', 'Running Post-Test Script', $pts_test_arguments, $extra_runtime_variables, true);
 
-			if($post_output != null && pts_client::is_debug_mode())
+			if($post_output != null && (pts_client::is_debug_mode() || $full_output))
 			{
 				pts_client::$display->test_run_instance_output($post_output);
 			}


### PR DESCRIPTION
This address issue #95 - FullOutput configuration option is added
If set the output of pre/test/interim/post is dumped to stdout