### PR TITLE
Run graphics detection only if required

### DIFF
--- a/pts-core/modules/graphics_event_checker.php
+++ b/pts-core/modules/graphics_event_checker.php
@@ -28,8 +28,8 @@ class graphics_event_checker extends pts_module_interface
 	const module_description = 'This module checks a number of events prior to and and after running a test to make sure the graphics sub-system was not put in a sour or unintended state by the application. For instance, it makes sure syncing to vBlank is not forced through the driver and that a graphics test has not left the display in an unintended mode.';
 	const module_author = 'Michael Larabel';
 
-	static $start_video_resolution = array(-1, -1);
-	static $driver_forced_vsync = false;
+	private static $start_video_resolution = array(-1, -1);
+	private static $driver_forced_vsync = false;
 
 	// GPU Errors
 	static $error_pointer = 0;
@@ -152,7 +152,7 @@ class graphics_event_checker extends pts_module_interface
 			echo PHP_EOL . 'GPU Errors: ' . $error_count . $error_breakdown . PHP_EOL;
 		}
 
-		if(phodevi::is_nvidia_graphics() && self::$driver_forced_vsync)
+		if(self::$driver_forced_vsync && phodevi::is_nvidia_graphics())
 		{
 			shell_exec('nvidia-settings -a SyncToVBlank=1 2>&1');
 		}

--- a/pts-core/objects/phodevi/phodevi.php
+++ b/pts-core/objects/phodevi/phodevi.php
@@ -24,11 +24,12 @@
 class phodevi extends phodevi_base
 {
 	public static $vfs = false;
-	private static $device_cache = null;
-	private static $smart_cache = null;
+	private static $device_cache = array();
+	private static $smart_cache = array();
 	private static $sensors = null;
 
 	private static $operating_system = null;
+	private static $graphics_detected = false;
 	private static $graphics = array(
 		'mesa' => false,
 		'ati' => false,
@@ -372,6 +373,15 @@ class phodevi extends phodevi_base
 			self::$operating_system = 'Unknown';
 		}
 
+		self::load_sensors();
+	}
+	private static function detect_graphics()
+	{
+		if(self::$graphics_detected == true)
+		{
+			return;
+		}
+
 		// OpenGL / graphics detection
 		$graphics_detection = array('NVIDIA', array('ATI', 'AMD', 'fglrx'), array('Mesa', 'SGI'));
 		$opengl_driver = phodevi::read_property('system', 'opengl-vendor') . ' ' . phodevi::read_property('system', 'opengl-driver') . ' ' . phodevi::read_property('system', 'dri-display-driver');
@@ -394,7 +404,7 @@ class phodevi extends phodevi_base
 			}
 		}
 
-		self::load_sensors();
+		self::$graphics_detected = true;
 	}
 	public static function set_device_cache($cache_array)
 	{
@@ -576,14 +586,17 @@ class phodevi extends phodevi_base
 	}
 	public static function is_mesa_graphics()
 	{
+		self::detect_graphics();
 		return self::$graphics['mesa'];
 	}
 	public static function is_ati_graphics()
 	{
+		self::detect_graphics();
 		return self::$graphics['ati'];
 	}
 	public static function is_nvidia_graphics()
 	{
+		self::detect_graphics();
 		return self::$graphics['nvidia'];
 	}
 	public static function is_root()


### PR DESCRIPTION
This improves performance of "./phoronix-test-suite help" for example.