### PR TITLE
pts-core: prevent reinstall of present packages

### DIFF
--- a/pts-core/external-test-dependencies/scripts/install-arch-packages.sh
+++ b/pts-core/external-test-dependencies/scripts/install-arch-packages.sh
@@ -3,5 +3,5 @@
 # Arch package installation
 
 echo "Please enter your root password below:" 1>&2
-su root -c "pacman -Sy --noconfirm $*"
+su root -c "pacman -Sy --noconfirm --needed $*"
 exit


### PR DESCRIPTION
It's not necessary to reinstall packages that are already there, `--needed` will skip those