### PR TITLE
pts-core: Update latest Solus dependency libs

### DIFF
--- a/pts-core/external-test-dependencies/xml/solus-packages.xml
+++ b/pts-core/external-test-dependencies/xml/solus-packages.xml
@@ -42,7 +42,7 @@
 		</Package>
 		<Package>
 			<GenericName>build-utilities</GenericName>
-			<PackageName>gcc g++ libgomp autoconf automake m4 glibc-devel binutils make kernel-libc-devel</PackageName>
+			<PackageName>-c system.devel</PackageName>
 		</Package>
 		<Package>
 			<GenericName>tiff</GenericName>
@@ -164,7 +164,13 @@
 		</Package>
 		<Package>
 			<GenericName>lapack-development</GenericName>
-			<PackageName>lapack-devel</PackageName>
+			<PackageName>openblas-devel</PackageName>
+			<FileCheck>lapacke.h</FileCheck>
+		</Package>
+		<Package>
+			<GenericName>atlas-development</GenericName>
+			<PackageName>gflags-devel glog-devel leveldb-devel lmdb-devel hdf5-devel opencv-devel protobuf-devel snappy-devel</PackageName>
+			<FileCheck>gflags.h</FileCheck>
 		</Package>
 		<Package>
 			<GenericName>cmake</GenericName>
@@ -237,6 +243,10 @@
 			<PackageName>golang</PackageName>
 		</Package>
 		<Package>
+			<GenericName>redis-server</GenericName>
+			<PackageName>redis</PackageName>
+		</Package>
+		<Package>
 			<GenericName>opencv</GenericName>
 			<PackageName>opencv-devel</PackageName>
 		</Package>
@@ -249,6 +259,11 @@
 			<GenericName>python-scipy</GenericName>
 			<PackageName>scipy</PackageName>
 			<FileCheck>/usr/lib/python2.7/site-packages/scipy</FileCheck>
+		</Package>
+		<Package>
+			<GenericName>python-sklearn</GenericName>
+			<PackageName>scikit-learn</PackageName>
+			<FileCheck>/usr/lib/python2.7/site-packages/sklearn</FileCheck>
 		</Package>
 	</ExternalDependencies>
 </PhoronixTestSuite>


### PR DESCRIPTION
Hi Michael,

Here's another quick patch to make Solus work great out of the box with the PTS (including the caffe test, though maybe not rbenchmark). It has the new packages to run those BLAS tests that are now in the Solus repo and uses our build essential equivalent. Thought I'd sneak it in before 6.8

I tested in a VM, installing Solus, updating Solus, reboot (for kernel), install PTS and install/run the tests and it sorted itself out all the deps with this new patch. It does give the odd error with the dependency not being met, but all the right packages are installed anyway.

I shall get back to testing those CL avx2 patches and see how they pan out :D
Cheers