### PR TITLE
Allow GRAPH_HIGHLIGHT in a form "will_be_different,group1a=1,group1b=1,blue=#0000ff"

### DIFF
--- a/documentation/phoronix-test-suite.html
+++ b/documentation/phoronix-test-suite.html
@@ -328,7 +328,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <p><strong>PTS_DOWNLOAD_CACHE</strong></p>
 <p>While non-standard Phoronix Test Suite download caches can be specified within the <em>user-config.xml</em> file, an additional directory to look for potential Phoronix Test Suite download files can be specified by this variable.</p>
 <p><strong>GRAPH_HIGHLIGHT</strong></p>
-<p>If this variable is set with a valid test identifer from a result file whether you are using the <em>refresh-graphs</em> command or any other related to the rendering of test results on a bar graph, the specified test identifier's result will be highlighted in a different color than the other rendered test results. Multiple identifiers can be specified when delimited by a comma.</p>
+<p>If this variable is set with a valid test identifer from a result file whether you are using the <em>refresh-graphs</em> command or any other related to the rendering of test results on a bar graph, the specified test identifier's result will be rendered in a different color than the other test results. Multiple identifiers can be specified when delimited by a comma. Additionally, for each key it is possible to provide the actual color value, or an index in the color palette. Example: "will_be_different,group1a=1,group1b=1,blue=#0000ff"</p>
 <p><strong>VIDEO_MEMORY</strong></p>
 <p>If Phodevi fails to detect the system's video memory capacity or is incorrectly detected, the video memory capacity (in MB) can be specified by this variable.</p>
 <p><strong>OVERRIDE_VIDEO_MODES</strong></p>

--- a/pts-core/objects/pts_Graph/pts_graph_box_plot.php
+++ b/pts-core/objects/pts_Graph/pts_graph_box_plot.php
@@ -113,7 +113,7 @@ class pts_graph_box_plot extends pts_graph_horizontal_bars
 					$box_color = $paint_color;
 				}
 
-				$box_color = in_array($buffer_item->get_result_identifier(), $this->value_highlights) ? $this->darken_color($box_color) : $box_color;
+				$box_color = $this->adjust_color($buffer_item->get_result_identifier(), $box_color);
 
 				$this->svg_dom->add_element('line', array('x1' => $value_end_left, 'y1' => $middle_of_bar, 'x2' => $value_end_right, 'y2' => $middle_of_bar), $g_lines);
 				$this->svg_dom->add_element('line', array('x1' => $value_end_left, 'y1' => $px_bound_top, 'x2' => $value_end_left, 'y2' => $px_bound_bottom), $g_lines);

--- a/pts-core/objects/pts_Graph/pts_graph_horizontal_bars.php
+++ b/pts-core/objects/pts_Graph/pts_graph_horizontal_bars.php
@@ -109,7 +109,7 @@ class pts_graph_horizontal_bars extends pts_graph_core
 				if($identifier == 0 && !$this->is_multi_way_comparison)
 				{
 					// See if the result identifier matches something to be color-coded better
-					$paint_color = self::identifier_to_branded_color($buffer_item->get_result_identifier(), $this->get_paint_color($identifier));
+					$paint_color = self::identifier_to_branded_color($buffer_item->get_result_identifier(), $this->get_paint_color($buffer_item->get_result_identifier()));
 				}
 
 				$value = $buffer_item->get_result_value();

--- a/pts-core/objects/pts_Graph/pts_graph_horizontal_bars.php
+++ b/pts-core/objects/pts_Graph/pts_graph_horizontal_bars.php
@@ -109,7 +109,7 @@ class pts_graph_horizontal_bars extends pts_graph_core
 				if($identifier == 0 && !$this->is_multi_way_comparison)
 				{
 					// See if the result identifier matches something to be color-coded better
-					$paint_color = self::identifier_to_branded_color($buffer_item->get_result_identifier(), $this->get_paint_color($buffer_item->get_result_identifier()));
+					$paint_color = self::identifier_to_branded_color($buffer_item->get_result_identifier(), $this->get_paint_color($identifier));
 				}
 
 				$value = $buffer_item->get_result_value();
@@ -146,7 +146,7 @@ class pts_graph_horizontal_bars extends pts_graph_core
 					}
 				}
 
-				$this->svg_dom->add_element('rect', array('x' => $this->i['left_start'], 'y' => $px_bound_top, 'height' => $bar_height, 'width' => $graph_size, 'fill' => (in_array($buffer_item->get_result_identifier(), $this->value_highlights) ? $this->darken_color($paint_color) : $paint_color), 'xlink:title' => $title_tooltip), $g_bars);
+				$this->svg_dom->add_element('rect', array('x' => $this->i['left_start'], 'y' => $px_bound_top, 'height' => $bar_height, 'width' => $graph_size, 'fill' => $this->adjust_color($buffer_item->get_result_identifier(), $paint_color), 'xlink:title' => $title_tooltip), $g_bars);
 
 				if($std_error != -1 && $std_error > 0 && $value != null)
 				{


### PR DESCRIPTION
Follow up to my previous approach.

I'm not in love with this code, as there seem to be too many places where the color of the line is now decided. But I do not fully grasp all the ideas there, so let's see if this works.

Btw, the "index" syntax can be quite useful to easily group runs with the same color.

This should be backward compatible, as long as people don't have runs with IDs containing =.