### PR TITLE
Remove globbing of arguments for pre/interim/post scripts

### DIFF
--- a/pts-core/objects/client/pts_tests.php
+++ b/pts-core/objects/client/pts_tests.php
@@ -232,7 +232,7 @@ class pts_tests
 				}
 				else
 				{
-					$this_result = pts_client::shell_exec('cd ' .  $test_directory . ' && ' . $sh . ' ' . $run_file . ' "' . $pass_argument . '" 2>&1', $extra_vars);
+					$this_result = pts_client::shell_exec('cd ' .  $test_directory . ' && ' . $sh . ' ' . $run_file . ' ' . $pass_argument . ' 2>&1', $extra_vars);
 				}
 
 				if(trim($this_result) != null)


### PR DESCRIPTION
To ensure they behave like the main executable.

This appears to be the intended behaviour, as globbed arguments aren't as useful as keeping them separate. This may break any tests that rely on that behaviour though, but works for the few that I tried.

This is needed for https://github.com/phoronix-test-suite/test-profiles/pull/2