### PR TITLE
Updated dependencies for Ubuntu 16.04

### DIFF
--- a/pts-core/external-test-dependencies/xml/ubuntu-packages.xml
+++ b/pts-core/external-test-dependencies/xml/ubuntu-packages.xml
@@ -89,11 +89,11 @@
 		</Package>
 		<Package>
 			<GenericName>java</GenericName>
-			<PackageName>openjdk-6-jre</PackageName>
+			<PackageName>openjdk-8-jre</PackageName>
 		</Package>
 		<Package>
 			<GenericName>portaudio-development</GenericName>
-			<PackageName>libportaudio-dev</PackageName>
+			<PackageName>portaudio19-dev</PackageName>
 		</Package>
 		<Package>
 			<GenericName>fortran-compiler</GenericName>


### PR DESCRIPTION
On Ubuntu 16.04 and greater there are 2 packages that aren't installable from the standard repos.  They have been superseded by newer packages.

`openjdk-6-jre` can be replaced with `openjdk-8-jre`
`libportaudio-dev` can be replaced with `portaudio19-dev`