### PR TITLE
Network IP+Mac now use default gateway device

### DIFF
--- a/pts-core/commands/network_info.php
+++ b/pts-core/commands/network_info.php
@@ -29,6 +29,7 @@ class network_info implements pts_option_interface
 	{
 		$table = array();
 		$table[] = array('Local IP:', pts_network::get_local_ip());
+		$table[] = array('Interface:', pts_network::get_active_network_interface());
 		$table[] = array('Network MAC: ', pts_network::get_network_mac());
 		$table[] = array('Wake On LAN: ', implode(' ', pts_network::get_network_wol()));
 


### PR DESCRIPTION
So PTS was getting the first IP/MAC address in the list (which for me was my docker0 device).

I figured the IP and Mac addresses that we actually want is the one associated with the default gateway device.

if the default network interface cannot be determined, the previous behaviour for IP and MAC addresses is used.