### PR TITLE
make script shebang more portable

### DIFF
--- a/pts-core/objects/client/pts_test_installer.php
+++ b/pts-core/objects/client/pts_test_installer.php
@@ -553,7 +553,7 @@ class pts_test_installer
 
 				// Write the main mask for the compiler
 				file_put_contents($main_compiler,
-					'#!/bin/bash' . PHP_EOL . 'COMPILER_OPTIONS="$@"' . PHP_EOL . $env_var_check . PHP_EOL . 'echo $COMPILER_OPTIONS >> ' . $mask_dir . $compiler_type . '-options-' . $compiler_name . PHP_EOL . $compiler_path . ' "$@"' . PHP_EOL);
+					'#!/usr/bin/env bash' . PHP_EOL . 'COMPILER_OPTIONS="$@"' . PHP_EOL . $env_var_check . PHP_EOL . 'echo $COMPILER_OPTIONS >> ' . $mask_dir . $compiler_type . '-options-' . $compiler_name . PHP_EOL . $compiler_path . ' "$@"' . PHP_EOL);
 
 				// Make executable
 				chmod($main_compiler, 0755);


### PR DESCRIPTION
On [NixOS](http://nixos.org/) there is no /bin/bash. /usr/bin/env should be also more
portable on BSD and other *nix systems.

I used the following `default.nix` to get all dependencies for phoronix-test-suite (making a proper image should be easy).

```
with import <nixpkgs> {};
stdenv.mkDerivation {
  name = "env";
  buildInputs = [
    php
    autoreconfHook
    popt
    libaio
    perl
    gcc7
    pcre
    glibc.out
    glibc.static
  ];
  hardeningDisable = [ "all" ];
}
```