### PR TITLE
Always execute test scripts in test directory

### DIFF
--- a/pts-core/objects/client/pts_tests.php
+++ b/pts-core/objects/client/pts_tests.php
@@ -224,6 +224,11 @@ class pts_tests
 					pts_client::$display->test_run_message($print_string);
 				}
 
+				// Script's working directory should be the test directory
+				$original_directory = getcwd();
+				chdir($test_directory);
+
+				// Execute script
 				if(phodevi::is_windows() || pts_client::read_env('USE_PHOROSCRIPT_INTERPRETER') != false)
 				{
 					$phoroscript = new pts_phoroscript_interpreter($run_file, $extra_vars, $test_directory);
@@ -232,8 +237,11 @@ class pts_tests
 				}
 				else
 				{
-					$this_result = pts_client::shell_exec('cd ' .  $test_directory . ' && ' . $sh . ' ' . $run_file . ' ' . $pass_argument . ' 2>&1', $extra_vars);
+					$this_result = pts_client::shell_exec($sh . ' ' . $run_file . ' ' . $pass_argument . ' 2>&1', $extra_vars);
 				}
+
+				// Restore working directory
+				chdir($original_directory);
 
 				if(trim($this_result) != null)
 				{


### PR DESCRIPTION
Script's working directory should be the test directory, currently this is not satisfied when running on Windows.

More concretely, this fixes the bug outlined in the comments of following code in "install_windows.sh" of test profile "eliasvan/supertuxkart-1.5.0":

    # Note: first command is commented because there's a bug in PTS for Windows: the current working dir is not set to the test dir while executing this script,
    #       therefore the second command is used instead as workaround;
    #       once this bug is fixed please uncomment the first command and remove the second one, together with this note
    #supertuxkart-0.9.3-win64.exe /S /D=%cd%\\supertuxkart-0.9.3-win64
    start cmd /C "set _test_install_directory=$1 && call cd ^%_test_install_directory^% && call supertuxkart-0.9.3-win64.exe /S /D=^%cd^%\supertuxkart-0.9.3-win64"

Tested with Windows 10, Wine, and Ubuntu 16.04.