### PR TITLE
Set script-requested cwd when executing command

### DIFF
--- a/pts-core/objects/client/pts_phoroscript_interpreter.php
+++ b/pts-core/objects/client/pts_phoroscript_interpreter.php
@@ -340,15 +340,17 @@ class pts_phoroscript_interpreter
 					}
 
 					$this->parse_variables_in_string($line, $pass_arguments);
-					$cd_dir = $this->var_current_directory;
 
-					if(phodevi::is_windows() && strpos($cd_dir, ':\\') === 1)
-					{
-						$cd_dir = str_replace('/', '\\', $cd_dir);
-						$cd_dir = str_replace('\\\\', '\\', $cd_dir);
-					}
+					// Set the requested current working dir while executing the command
+					$original_directory = getcwd();
+					chdir($this->var_current_directory);
 
-					exec("cd " . $cd_dir . " && " . $line . " 2>&1", $exec_output, $prev_exit_status);
+					// Execute command
+					exec($line . " 2>&1", $exec_output, $prev_exit_status);
+
+					// Restore original working directory
+					chdir($original_directory);
+
 					break;
 			}
 		}


### PR DESCRIPTION
This fixes https://github.com/phoronix-test-suite/phoronix-test-suite/issues/232:
'Commands in scripts interpreted by phoroscript_interpreter are not executed in a context where the current working directory is set as requested by the script'

This also removes the need of the workaround performed in "install_windows.sh" (https://openbenchmarking.org/innhold/a97d4ee6ea8b6410ca8f739f296f98d5002e05a6 , see "# Note: ...") in https://openbenchmarking.org/test/eliasvan/supertuxkart-1.5.1

Tested with Windows 10, Wine, and Ubuntu 16.04.