### PR TITLE
pts-core: prepend EXECUTE_BINARY_PREPEND in test run request

### DIFF
--- a/pts-core/objects/client/pts_test_execution.php
+++ b/pts-core/objects/client/pts_test_execution.php
@@ -117,6 +117,10 @@ class pts_test_execution
 		{
 			$execute_binary_prepend = $test_run_request->exec_binary_prepend;
 		}
+        else if(getenv('EXECUTE_BINARY_PREPEND') != false)
+        {
+			$execute_binary_prepend = getenv('EXECUTE_BINARY_PREPEND') . ' ';
+        }
 
 		if(!$cache_share_present && !$test_run_manager->DEBUG_no_test_execution_just_result_parse && $test_run_request->test_profile->is_root_required())
 		{


### PR DESCRIPTION
This new environment variable may specify a command which can be prepended
into the main test command. One important usage can be when profiling
a certain test and neither flamegrapher nor linux_perf pts-core modules give
us what we want.

Two simple examples on this area

* use /usr/bin/time -v to get some basic stats

    $ export EXECUTE_BINARY_PREPEND='/usr/bin/time -v' && \
    phoronix-test-suite run ..

* perf-record and leave data (perf.data) in the installed directory

    $ export EXECUTE_BINARY_PREPEND='perf record -a -g -F 97 -o perf.data' && \
    phoronix-test-suite run ..

NOTE: If either LINUX_PERF or FLAME_GRAPH_PATH environment
variables are present on the environment, EXECUTE_BINARY_PREPEND wont have any
effect.

Signed-off-by: Leonardo Sandoval <leonardo.sandoval.gonzalez@linux.intel.com>