### PR TITLE
install-fedora-packages.sh: Add sudo password prompt

### DIFF
--- a/pts-core/external-test-dependencies/scripts/install-fedora-packages.sh
+++ b/pts-core/external-test-dependencies/scripts/install-fedora-packages.sh
@@ -9,7 +9,7 @@ elif [ `whoami` = "ec2-user" ]; then
 	sudo yum -y --skip-broken install $*
 else
 	echo "Please enter your SUDO password below:" 1>&2 
-        read -s -p "Password: " passwd
+	read -s -p "Password: " passwd
 	if ! echo $passwd | sudo -S -p '' yum -y --skip-broken install $*; then
         	echo "Please enter your ROOT password below:" 1>&2
 		su root -c "yum -y --skip-broken install $*"

--- a/pts-core/external-test-dependencies/scripts/install-fedora-packages.sh
+++ b/pts-core/external-test-dependencies/scripts/install-fedora-packages.sh
@@ -8,8 +8,12 @@ elif [ -x /usr/bin/dnf ]; then
 elif [ `whoami` = "ec2-user" ]; then
 	sudo yum -y --skip-broken install $*
 else
-	echo "Please enter your root password below:" 1>&2
-	su root -c "yum -y --skip-broken install $*"
+	echo "Please enter your SUDO password below:" 1>&2 
+        read -s -p "Password: " passwd
+	if ! echo $passwd | sudo -S -p '' yum -y --skip-broken install $*; then
+        	echo "Please enter your ROOT password below:" 1>&2
+		su root -c "yum -y --skip-broken install $*"
+	fi
 fi
 
 exit


### PR DESCRIPTION
#268 
Add sudo password prompt alongside root prompt for fedora/centos/rh distributions.

The prompt comes before the `su` attempt.

`su` will still be attempted should the `sudo` password be incorrect.