### PR TITLE
install-arch-packages.sh: Add --asdeps option

### DIFF
--- a/pts-core/external-test-dependencies/scripts/install-arch-packages.sh
+++ b/pts-core/external-test-dependencies/scripts/install-arch-packages.sh
@@ -3,5 +3,5 @@
 # Arch package installation
 
 echo "Please enter your root password below:" 1>&2
-su root -c "pacman -Sy --noconfirm --needed $*"
+su root -c "pacman -Sy --noconfirm --needed --asdeps $*"
 exit


### PR DESCRIPTION
With this option installed packages will result as 'orphan' for an easy removal when no more needed, this option is already added in the three AUR pkgbuilds