### PR TITLE
pts-core: Arch deps, fixed zlib name, add freeimage, removed double mesa-demos

### DIFF
--- a/pts-core/external-test-dependencies/xml/arch-packages.xml
+++ b/pts-core/external-test-dependencies/xml/arch-packages.xml
@@ -7,11 +7,6 @@
 			<PackageManager>pacman</PackageManager>
 		</Information>
 		<Package>
-			<GenericName>common-dependencies</GenericName>
-			<PackageName>mesa-demos</PackageName>
-			<FileCheck>glxinfo</FileCheck>
-		</Package>
-		<Package>
 			<GenericName>gtk-development</GenericName>
 			<PackageName>gtk2</PackageName>
 		</Package>
@@ -106,7 +101,7 @@
 		</Package>
 		<Package>
 			<GenericName>zlib-development</GenericName>
-			<PackageName>zlib1</PackageName>
+			<PackageName>zlib</PackageName>
 		</Package>
 		<Package>
 			<GenericName>jpeg-development</GenericName>
@@ -115,6 +110,10 @@
 		<Package>
 			<GenericName>bc</GenericName>
 			<PackageName>bc</PackageName>
+		</Package>
+		<Package>
+			<GenericName>freeimage</GenericName>
+			<PackageName>freeimage</PackageName>
 		</Package>
 		<Package>
 			<GenericName>perl</GenericName>


### PR DESCRIPTION
common-dependencies is already added (mesa-demos + unzip)
freeimage is required by universe-x
nothing complained about zlib but name is not zlib1