### PR TITLE
Fix test option: <DefaultEntry>0</DefaultEntry>

### DIFF
--- a/pts-core/objects/pts_test_option.php
+++ b/pts-core/objects/pts_test_option.php
@@ -45,7 +45,7 @@ class pts_test_option
 	}
 	public function set_option_default($default_node)
 	{
-		if($default_node == null)
+		if($default_node == null || $default_node == "0")
 			$default_node = 1;
 
 		$default_node--;


### PR DESCRIPTION
The DefaultEntry is 0 for the system/fio IO Engine, however default-benchmark runs tests with the last engine libaio.

https://github.com/phoronix-test-suite/test-profiles/blob/master/system/fio-1.9.0/test-definition.xml#L58
```
    58        <DefaultEntry>0</DefaultEntry>
    59        <Menu>
    60          <Entry>
    61            <Name>POSIX AIO</Name>
    62            <Value>posixaio</Value>
    63            <Message></Message>
    64          </Entry>
    65          <Entry>
    66            <Name>Sync</Name>
    67            <Value>sync</Value>
    68            <Message></Message>
    69          </Entry>
    70          <Entry>
    71            <Name>Libaio</Name>
    72            <Value>libaio</Value>
    73            <Message></Message>
    74          </Entry>
    75        </Menu>
```

```
% phoronix-test-suite default-benchmark system/fio

Phoronix Test Suite v8.2.0

    Installed:     system/fio-1.9.0
    Would you like to save these test results (Y/n): n


Flexible IO Tester:
    system/fio-1.9.0 [Type: Sequential Write - IO Engine: Libaio - Buffered: No - Direct: No - Block Size: 128MB - Disk Target: Default Test Directory]
    Test 1 of 4
    Estimated Trial Run Count:    3
    Estimated Test Run-Time:      1 Minute
    Estimated Time To Completion: 4 Minutes [16:31 UTC]
        Running Pre-Test Script @ 16:27:44
        Started Run 1 @ 16:27:45
        The test run did not produce a result.
```

the value of DefaultEntry is passed to set_option_default() as string "0"
https://github.com/phoronix-test-suite/phoronix-test-suite/blob/v8.2.0/pts-core/objects/pts_test_profile_parser.php#L453
```
   453                                  $user_option->set_option_default($option->DefaultEntry->__toString());
```

since $default_node (string "0") is not null, then the default_entry turns to be -1 here:
https://github.com/phoronix-test-suite/phoronix-test-suite/blob/v8.2.0/pts-core/objects/pts_test_option.php#L46
```
    46          public function set_option_default($default_node)
    47          {
    48                  if($default_node == null)
    49                          $default_node = 1;
    50  
    51                  $default_node--;
    52                  if(isset($this->options[$default_node]))
    53                  {
    54                          $this->default_entry = $default_node;
    55                  }
    56          }
```

and it returns the last the entry (libaio) as the default one.
https://github.com/phoronix-test-suite/phoronix-test-suite/blob/v8.2.0/pts-core/objects/pts_test_option.php#L85
```
    85          public function get_option_default()
    86          {               
    87                  return $this->default_entry == -1 ? $this->option_count() - 1 : $this->default_entry;
    88          }
```

