### PR TITLE
pts-core: Report on the POWER SMT setting in notes

### DIFF
--- a/pts-core/objects/client/pts_test_run_manager.php
+++ b/pts-core/objects/client/pts_test_run_manager.php
@@ -955,6 +955,13 @@ class pts_test_run_manager
 			{
 				$notes['cpu-scaling-governor'] = $scaling_governor;
 			}
+
+			// POWER processors have configurable SMT, 1-8 per core.
+			$smt = phodevi::read_property('cpu', 'smt');
+			if($smt)
+			{
+				$notes['cpu-smt'] = $smt;
+			}
 		}
 		if($show_all || in_array('Graphics', $test_hardware_types))
 		{

--- a/pts-core/objects/phodevi/components/phodevi_cpu.php
+++ b/pts-core/objects/phodevi/components/phodevi_cpu.php
@@ -42,7 +42,8 @@ class phodevi_cpu extends phodevi_device_interface
 			'scaling-governor' => new phodevi_device_property('cpu_scaling_governor', phodevi::std_caching),
 			'microcode-version' => new phodevi_device_property('cpu_microcode_version', phodevi::std_caching),
 			'cache-size' => new phodevi_device_property('cpu_cache_size', phodevi::smart_caching),
-			'cache-size-string' => new phodevi_device_property('cpu_cache_size_string', phodevi::smart_caching)
+			'cache-size-string' => new phodevi_device_property('cpu_cache_size_string', phodevi::smart_caching),
+			'smt' => new phodevi_device_property('cpu_smt', phodevi::std_caching),
 			);
 	}
 	public static function cpu_string()
@@ -303,6 +304,18 @@ class phodevi_cpu extends phodevi_device_interface
 		}
 
 		return trim($scaling_governor);
+	}
+	public static function cpu_smt()
+	{
+		$smt = false;
+
+		if(pts_client::executable_in_path('ppc64_cpu')) {
+			$ppc64 = trim(shell_exec('ppc64_cpu --smt -n | grep SMT= | cut -d= -f2'));
+			if(is_numeric($ppc64) && $ppc64 >= 1)
+				$smt = $ppc64;
+		}
+
+		return trim($smt);
 	}
 	public static function is_genuine($cpu)
 	{

--- a/pts-core/objects/pts_result_file_analyzer.php
+++ b/pts-core/objects/pts_result_file_analyzer.php
@@ -722,6 +722,11 @@ class pts_result_file_analyzer
 			$system_attributes['Processor'][$identifier] = 'Scaling Governor: ' . $json['cpu-scaling-governor'];
 			unset($json['cpu-scaling-governor']);
 		}
+		if(isset($json['cpu-smt']))
+		{
+			$system_attributes['Processor'][$identifier] = 'SMT (threads per core): ' . $json['cpu-smt'];
+			unset($json['cpu-smt']);
+		}
 		if(isset($json['graphics-2d-acceleration']) || isset($json['graphics-aa']) || isset($json['graphics-af']))
 		{
 			$report = array();


### PR DESCRIPTION
This is not the same as the reported cpu thread count from /proc/cpuinfo,
which are kind of virtual cores and don't have uniform numbering. Having the setting clearly displayed is also better than having to divide the threads by cores, even if it was correct.