### PR TITLE
minor grammar fix

### DIFF
--- a/pts-core/objects/pts_Graph/pts_graph_core.php
+++ b/pts-core/objects/pts_Graph/pts_graph_core.php
@@ -785,7 +785,7 @@ abstract class pts_graph_core
 				switch($this->i['graph_proportion'])
 				{
 					case 'LIB':
-						$proportion = 'Less Is Better';
+						$proportion = 'Fewer Is Better';
 						$offset += 12;
 
 						if($this->i['graph_orientation'] == 'HORIZONTAL')


### PR DESCRIPTION
Measurements are of discrete quantities and thus "Fewer" should be used instead of "Less."