### PR TITLE
Added different encoding modes for rav1e

### DIFF
--- a/ob-cache/test-profiles/git/rav1e-1.0.0/downloads.xml
+++ b/ob-cache/test-profiles/git/rav1e-1.0.0/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</URL>
+      <MD5>84ae521c95aa2537e16b34bbf72f2def</MD5>
+      <SHA256>e2f60b904789a60f6d1edc194d8540d401dd882e3ee3605b9b1de8feacc72133</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</FileName>
+      <FileSize>676792531</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/git/rav1e-1.0.0/install.sh
+++ b/ob-cache/test-profiles/git/rav1e-1.0.0/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+rm -rf rav1e-master
+git clone https://github.com/xiph/rav1e.git rav1e-master
+cargo build --release
+echo $? > ~/install-exit-status
+cd ~
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+cd rav1e-master
+cargo build --bin rav1e --release -j $NUM_CPU_PHYSICAL_CORES
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+./rav1e-master/target/release/rav1e ./Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output /dev/null \$@ > log.out 2>&1
+echo \$? > ~/test-exit-status
+
+tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e
+chmod +x rav1e

--- a/ob-cache/test-profiles/git/rav1e-1.0.0/results-definition.xml
+++ b/ob-cache/test-profiles/git/rav1e-1.0.0/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>INFO  rav1e::stats         &gt; encoded 600 frames, #_RESULT_# fps, 2066.87 Kb/s</OutputTemplate>
+    <LineHint>fps</LineHint>
+    <TurnCharsToSpace>(</TurnCharsToSpace>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/git/rav1e-1.0.0/test-definition.xml
+++ b/ob-cache/test-profiles/git/rav1e-1.0.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>AOM AV1</Title>
+    <AppVersion>Git</AppVersion>
+    <Description>This is a simple test of the AOMedia AV1 encoder run on the CPU with a sample video file.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>AV1 Video Encoding</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux, MacOSX, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, p7zip, cmake, perl, yasm, git</ExternalDependencies>
+    <EnvironmentSize>369</EnvironmentSize>
+    <ProjectURL>https://aomedia.googlesource.com/aom/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/rav1e-1.2.0/downloads.xml
+++ b/ob-cache/test-profiles/pts/rav1e-1.2.0/downloads.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</URL>
+      <MD5>84ae521c95aa2537e16b34bbf72f2def</MD5>
+      <SHA256>e2f60b904789a60f6d1edc194d8540d401dd882e3ee3605b9b1de8feacc72133</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</FileName>
+      <FileSize>676792531</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/xiph/rav1e/archive/0.1.0.tar.gz</URL>
+      <MD5>cd383e61e86eef0a689c9c951a4c7652</MD5>
+      <SHA256>00395087eaba4778d17878924e007716e2f399116b8011bf057fd54cc528a6cb</SHA256>
+      <FileName>rav1e-0.1.0.tar.gz</FileName>
+      <FileSize>637375</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>https://github.com/xiph/rav1e/releases/download/0.1.0/rav1e.exe</URL>
+      <MD5>7236d84cab5f9c5ecbbf9bdd6a34c161</MD5>
+      <SHA256>0956b4576536e30808346efcc74d4f6ab66c51e884eb9c3e4c2ae57181e233f3</SHA256>
+      <FileName>rav1e-01.exe</FileName>
+      <FileSize>4627456</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/rav1e-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/rav1e-1.2.0/install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+tar -xf rav1e-0.1.0.tar.gz
+cd rav1e-0.1.0
+cargo build --bin rav1e --release -j $NUM_CPU_PHYSICAL_CORES
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+cd rav1e-0.1.0
+./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output /dev/null \$@ > log.out 2>&1
+echo \$? > ~/test-exit-status
+
+tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e
+chmod +x rav1e

--- a/ob-cache/test-profiles/pts/rav1e-1.2.0/install_windows.sh
+++ b/ob-cache/test-profiles/pts/rav1e-1.2.0/install_windows.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+echo "#!/bin/sh
+./rav1e-01.exe Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output output \$@ > log.out 2>&1
+rm -f output
+
+tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e
+chmod +x rav1e

--- a/ob-cache/test-profiles/pts/rav1e-1.2.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/rav1e-1.2.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>encoded 60/60 frames, #_RESULT_# fps, 2306.73 Kb/s, est. size: 0.27 MB, est. time: 0s                    </OutputTemplate>
+    <LineHint>encoded 60/60</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/rav1e-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/rav1e-1.2.0/test-definition.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>rav1e</Title>
+    <AppVersion>0.1</AppVersion>
+    <Description>Xiph rav1e is a Rust-written AV1 video encoder.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>1080p To AV1 Video Encode</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>rust, yasm, perl, cmake</ExternalDependencies>
+    <EnvironmentSize>3000</EnvironmentSize>
+    <ProjectURL>https://github.com/xiph/rav1e</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Encoder Mode</DisplayName>
+      <Identifier>enc-mode</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Enc Mode 10</Name>
+          <Value>--speed 10 --limit 60</Value>
+          <Message>Fastest - Default</Message>
+        </Entry>
+        <Entry>
+          <Name>Enc Mode 5</Name>
+          <Value>--speed 5 --limit 60</Value>
+          <Message>Mid-Speed</Message>
+        </Entry>
+        <Entry>
+          <Name>Enc Mode 0</Name>
+          <Value>--speed 0 --limit 60</Value>
+          <Message>Slowest</Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Add option to choose encoding profile with speed=0 (highest quality) to speed=10 (fastest).
I didn't test this on windows as I don't have a windows machine to test on.