### PR TITLE
Update results-definition.xml

### DIFF
--- a/ob-cache/test-profiles/pts/netperf-1.0.3/results-definition.xml
+++ b/ob-cache/test-profiles/pts/netperf-1.0.3/results-definition.xml
@@ -2,22 +2,22 @@
 <!--Phoronix Test Suite v8.6.1-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate> #_RESULT_#</OutputTemplate>
+    <OutputTemplate>#_RESULT_#</OutputTemplate>
     <MatchToTestArguments>_STREAM</MatchToTestArguments>
     <ResultScale>Megabits/sec Throughput</ResultScale>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate> #_RESULT_#</OutputTemplate>
+    <OutputTemplate>#_RESULT_#</OutputTemplate>
     <MatchToTestArguments>_MAERTS</MatchToTestArguments>
     <ResultScale>Megabits/sec Throughput</ResultScale>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate> #_RESULT_#</OutputTemplate>
+    <OutputTemplate>#_RESULT_#</OutputTemplate>
     <MatchToTestArguments>_SENDFILE</MatchToTestArguments>
     <ResultScale>Megabits/sec Throughput</ResultScale>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate> #_RESULT_#</OutputTemplate>
+    <OutputTemplate>#_RESULT_#</OutputTemplate>
     <MatchToTestArguments>_RR</MatchToTestArguments>
     <ResultScale>Transaction Rate Per Second</ResultScale>
   </ResultsParser>


### PR DESCRIPTION
Space before #_RESULT_# key in the template is causing the first digit of the netperf result to be stripped and causing and test to return invalid data.
Example below from debug-benchmark run:

Test Run Command: cd /var/lib/phoronix-test-suite/installed-tests/pts/netperf-1.0.3/ && ./netperf -H 10.0.0.11 -t TCP_STREAM -l 10 2>&1

5835.85 

Result Key: #_RESULT_#


Template Line:  #_RESULT_#


Result Parsing Search Key: " "


Result Line: 835.85 


Test Result Parser Returning: 835.85