### PR TITLE
Add Persistent Memory disk targets for disk tests

### DIFF
--- a/pts-core/objects/pts_test_run_options.php
+++ b/pts-core/objects/pts_test_run_options.php
@@ -328,7 +328,7 @@ class pts_test_run_options
 				{
 					$all_devices = array();
 				}*/
-				$all_devices = array_merge(pts_file_io::glob('/dev/hd*'), pts_file_io::glob('/dev/sd*'), pts_file_io::glob('/dev/vd*'), pts_file_io::glob('/dev/md*'), pts_file_io::glob('/dev/nvme*'));
+				$all_devices = array_merge(pts_file_io::glob('/dev/hd*'), pts_file_io::glob('/dev/sd*'), pts_file_io::glob('/dev/vd*'), pts_file_io::glob('/dev/md*'), pts_file_io::glob('/dev/nvme*'),  pts_file_io::glob('/dev/pmem*'));
 
 				foreach($all_devices as &$device)
 				{
@@ -394,7 +394,7 @@ class pts_test_run_options
 					return;
 				}
 
-				$all_devices = array_merge(pts_file_io::glob('/dev/hd*'), pts_file_io::glob('/dev/sd*'), pts_file_io::glob('/dev/vd*'), pts_file_io::glob('/dev/md*'), pts_file_io::glob('/dev/nvme*'));
+				$all_devices = array_merge(pts_file_io::glob('/dev/hd*'), pts_file_io::glob('/dev/sd*'), pts_file_io::glob('/dev/vd*'), pts_file_io::glob('/dev/md*'), pts_file_io::glob('/dev/nvme*'),  pts_file_io::glob('/dev/pmem*'));
 
 				foreach($all_devices as $i => &$device)
 				{


### PR DESCRIPTION
The Linux native persistent memory drivers provide `/dev/pmem` entries fsdax and sector type namespaces that can be used to create file systems and be used either as block storage or with a persistent memory aware file system such as ext4 or XFS. 

When using the `auto-disk-mount-points` option in  `test-definition.xml`, it would not display the mounted file systems using /dev/pmem0 and /dev/pmem1. 

```
    <Option>
      <DisplayName>Disk Target</DisplayName>
      <Identifier>auto-disk-mount-points</Identifier>
      <ArgumentPrefix></ArgumentPrefix>
      <ArgumentPostfix></ArgumentPostfix>
      <DefaultEntry></DefaultEntry>
    </Option>
```

I saw only the following when running the test suite:

```
1: Default Test Directory
2: /
3: Test All Options
** Multiple items can be selected, delimit by a comma. **
```

With the proposed change, I do now see the file systems I need:

```
1: Default Test Directory
2: /pmemfs0
3: /pmemfs1
4: /
5: Test All Options
** Multiple items can be selected, delimit by a comma. **
```