### PR TITLE
Disabling progress bars speeds up Invoke-WebRequest

### DIFF
--- a/phoronix-test-suite.bat
+++ b/phoronix-test-suite.bat
@@ -36,12 +36,12 @@ If defined PHP_BIN goto SkipBinSearch
 If not exist C:\PHP\php.exe (
 echo Attempting to download and setup Windows PHP release.
 If not exist php.zip (
-powershell -command "& { iwr http://phoronix-test-suite.com/benchmark-files/php-7.2.3-Win32-VC15-x64.zip -OutFile php.zip }"
+powershell -command "& { $ProgressPreference = 'SilentlyContinue'; iwr http://phoronix-test-suite.com/benchmark-files/php-7.2.3-Win32-VC15-x64.zip -OutFile php.zip; $ProgressPreference = 'Continue' }"
 )
 powershell -command "& { Expand-Archive php.zip -DestinationPath C:\PHP }"
 If not exist VC_redist.x64.exe (
 echo Attempting to download and run Visual C++ Redistributable for Visual Studio 2017 support.
-powershell -command "& { iwr https://go.microsoft.com/fwlink/?LinkId=746572 -OutFile VC_redist.x64.exe }"
+powershell -command "& { $ProgressPreference = 'SilentlyContinue'; iwr https://go.microsoft.com/fwlink/?LinkId=746572 -OutFile VC_redist.x64.exe; $ProgressPreference = 'Continue' }"
 VC_redist.x64.exe
 )
   )


### PR DESCRIPTION
The PowerShell progress bar makes Invoke-WebRequest dramatically slower than it needs to be.  This adds a command to disable the progress bar, and then re-enable it once the download is complete.

https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download