### PR TITLE
Fix running pts/fio on external mount points

### DIFF
--- a/ob-cache/test-profiles/pts/fio-1.13.0/install.sh
+++ b/ob-cache/test-profiles/pts/fio-1.13.0/install.sh
@@ -18,7 +18,7 @@ if [ \"X\$6\" = \"X\" ]
 then
 	DIRECTORY_TO_TEST=\"fiofile\"
 else
-	DIRECTORY_TO_TEST=\"\$6\"
+	DIRECTORY_TO_TEST=\"\$6/fiofile\"
 fi
 echo \"[global]
 rw=\$1


### PR DESCRIPTION
Does this patch make sense?

I can't get `pts/fio` working without this on my external SSDs. The test automatically detects the mount point, and I can select it just fine, like this:

```
1: Default Test Directory
2: /media/lucas/XXX
3: Test All Options
** Multiple items can be selected, delimit by a comma. **
Disk Target: 2
```

But upon running the script (in debug mode), it fails with `The test run did not produce a result.`

```
Running Pre-Test Script

========================================
Flexible IO Tester (Run 1 of 1)
========================================


Test Run Command: cd /home/lucas/.phoronix-test-suite/installed-tests/pts/fio-1.13.0/ && ./fio-run randread libaio 0 1 4k /media/lucas/RPI_SSD_M2 2>&1

fio: pid=0, err=21/file:filesetup.c:150, func=unlink, error=Is a directory
```

With this patch, it works (for me at least :smile:).

I'm using the latest 1.13.0 version.
Thank you for the great tool!