### PR TITLE
Update test-definition.xml

### DIFF
--- a/ob-cache/test-profiles/pts/build-linux-kernel-1.10.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/build-linux-kernel-1.10.0/test-definition.xml
@@ -18,7 +18,7 @@
     <TestType>Processor</TestType>
     <License>Free</License>
     <Status>Verified</Status>
-    <ExternalDependencies>build-utilities, bc, bison, flex, openssl-development</ExternalDependencies>
+    <ExternalDependencies>build-utilities, bc, bison, elfutils-libelf-devel, flex, openssl-development</ExternalDependencies>
     <EnvironmentSize>125</EnvironmentSize>
     <ProjectURL>http://www.kernel.org/</ProjectURL>
     <InternalTags>SMP</InternalTags>


### PR DESCRIPTION
warning: Cannot use CONFIG_STACK_VALIDATION=y, please install libelf-dev, libelf-devel or elfutils-libelf-devel

test was failing for me, had to use debug-run to diagnose and this error came up. ( Fedora )