### PR TITLE
Updated BRL-CAD from 7.28.0 to 7.38.8 in order to fix build

### DIFF
--- a/ob-cache/test-profiles/pts/brl-cad-1.0.1/downloads.xml
+++ b/ob-cache/test-profiles/pts/brl-cad-1.0.1/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://superb-sea2.dl.sourceforge.net/project/brlcad/BRL-CAD%20Source/7.28.0/brlcad-7.28.0.tar.bz2, https://iweb.dl.sourceforge.net/project/brlcad/BRL-CAD%20Source/7.28.0/brlcad-7.28.0.tar.bz2, https://managedway.dl.sourceforge.net/project/brlcad/BRL-CAD%20Source/7.28.0/brlcad-7.28.0.tar.bz2</URL>
-      <MD5>bbd56e0c6c32e8433ae328903652e44b</MD5>
-      <SHA256>c6df320117fd50ecada5745a6f4c079b361df240915ed9c536aa1b697548a466</SHA256>
-      <FileName>brlcad-7.28.0.tar.bz2</FileName>
-      <FileSize>117290430</FileSize>
+      <URL>https://superb-sea2.dl.sourceforge.net/project/brlcad/BRL-CAD%20Source/7.30.8/brlcad-7.30.8.tar.bz2, https://iweb.dl.sourceforge.net/project/brlcad/BRL-CAD%20Source/7.30.8/brlcad-7.30.8.tar.bz2, https://managedway.dl.sourceforge.net/project/brlcad/BRL-CAD%20Source/7.30.8/brlcad-7.30.8.tar.bz2</URL>
+      <MD5>4e2f34eaca6e6f224f63a29a0735b4fb</MD5>
+      <SHA256>bb5dbcffb2a58d17963e74ed9ac83b2659fd2451b366b50e4961a9ea799aef7f</SHA256>
+      <FileName>brlcad-7.30.8.tar.bz2</FileName>
+      <FileSize>125443351</FileSize>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/brl-cad-1.0.1/install.sh
+++ b/ob-cache/test-profiles/pts/brl-cad-1.0.1/install.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
-tar -xf brlcad-7.28.0.tar.bz2
+tar -xf brlcad-7.30.8.tar.bz2
 
-mkdir brlcad-7.28.0/build
-cd brlcad-7.28.0/build
+mkdir brlcad-7.30.8/build
+cd brlcad-7.30.8/build
 cmake .. -DBRLCAD_ENABLE_STRICT=NO -DBRLCAD_BUNDLED_LIBS=ON -DBRLCAD_OPTIMIZED_BUILD=ON -DCMAKE_BUILD_TYPE=Release
 make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status
 cd ~
 
 echo "#!/bin/sh
-cd brlcad-7.28.0/build
+cd brlcad-7.30.8/build
 ./bench/benchmark run -P\$NUM_CPU_CORES > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status" > brl-cad
 chmod +x brl-cad

--- a/ob-cache/test-profiles/pts/brl-cad-1.0.1/test-definition.xml
+++ b/ob-cache/test-profiles/pts/brl-cad-1.0.1/test-definition.xml
@@ -3,8 +3,8 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>BRL-CAD</Title>
-    <AppVersion>7.28.0</AppVersion>
-    <Description>BRL-CAD 7.28.0 is a cross-platform, open-source solid modeling system with built-in benchmark mode.</Description>
+    <AppVersion>7.30.8</AppVersion>
+    <Description>BRL-CAD 7.30.8 is a cross-platform, open-source solid modeling system with built-in benchmark mode.</Description>
     <ResultScale>VGR Performance Metric</ResultScale>
     <Proportion>HIB</Proportion>
     <SubTitle>VGR Performance Metric</SubTitle>


### PR DESCRIPTION
BRL-CAD no longer builds on modern CMake due to a change in build dependencies. The latest upstream BRL-CAD fixes this issue