### PR TITLE
phodevi: Fix bug where idling fans are marked as unsupported sensors

### DIFF
--- a/pts-core/objects/phodevi/sensors/cpu_fanspeed.php
+++ b/pts-core/objects/phodevi/sensors/cpu_fanspeed.php
@@ -39,11 +39,11 @@ class cpu_fanspeed extends phodevi_sensor
 	private function cpu_fanspeed_linux()
 	{
 		$fan_speed = -1;
-		$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/device/fan1_input', 'POSITIVE_NUMERIC');
+		$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/device/fan1_input', 'NUMERIC');
 
 		if($raw_fan == -1)
 		{
-			$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan1_input', 'POSITIVE_NUMERIC');
+			$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan1_input', 'NUMERIC');
 		}
 
 		if($raw_fan != -1)

--- a/pts-core/objects/phodevi/sensors/gpu_fanspeed.php
+++ b/pts-core/objects/phodevi/sensors/gpu_fanspeed.php
@@ -38,7 +38,7 @@ class gpu_fanspeed extends phodevi_sensor
 			// nvidia-settings --describe GPUFanTarget 
 			$fan_speed = phodevi_parser::read_nvidia_extension('[fan:0]/GPUCurrentFanSpeed');
 		}
-		else if($fan1_input = phodevi_linux_parser::read_sysfs_node('/sys/class/drm/card0/device/hwmon/hwmon*/fan1_input', 'POSITIVE_NUMERIC'))
+		else if($fan1_input = phodevi_linux_parser::read_sysfs_node('/sys/class/drm/card0/device/hwmon/hwmon*/fan1_input', 'NUMERIC'))
 		{
 			// AMDGPU path
 			$fan_speed = round($fan1_input / phodevi_linux_parser::read_sysfs_node('/sys/class/drm/card0/device/hwmon/hwmon*/fan1_max', 'POSITIVE_NUMERIC') * 100, 2);

--- a/pts-core/objects/phodevi/sensors/sys_fanspeed.php
+++ b/pts-core/objects/phodevi/sensors/sys_fanspeed.php
@@ -40,16 +40,16 @@ class sys_fanspeed extends phodevi_sensor
 	private function sys_fanspeed_linux()
 	{
 		$fan_speed = -1;
-		$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan2_input', 'POSITIVE_NUMERIC');
+		$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan2_input', 'NUMERIC');
 
 		if($raw_fan == -1)
 		{
-			$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan3_input', 'POSITIVE_NUMERIC');
+			$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan3_input', 'NUMERIC');
 		}
 
 		if($raw_fan == -1)
 		{
-			$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan4_input', 'POSITIVE_NUMERIC');
+			$raw_fan = phodevi_linux_parser::read_sysfs_node('/sys/class/hwmon/hwmon*/fan4_input', 'NUMERIC');
 		}
 
 		if($raw_fan == -1)


### PR DESCRIPTION
In laptops, fans can idle when they are not needed and the sensors will read a 0 when the fans are idle.
This PR will change the fan speed checks to allow for a value of 0.