### PR TITLE
macOS: use the actual CPU model, not the 6-core i7 BS

### DIFF
--- a/pts-core/objects/phodevi/components/phodevi_cpu.php
+++ b/pts-core/objects/phodevi/components/phodevi_cpu.php
@@ -552,7 +552,12 @@ class phodevi_cpu extends phodevi_device_interface
 		}
 		else if(phodevi::is_macosx())
 		{
-			$info = phodevi_osx_parser::read_osx_system_profiler('SPHardwareDataType', 'ProcessorName');
+			$info = phodevi_bsd_parser::read_sysctl('machdep.cpu.brand_string');
+
+			if(empty($info))
+			{
+				$info = phodevi_osx_parser::read_osx_system_profiler('SPHardwareDataType', 'ProcessorName');
+			}
 		}
 		else if(phodevi::is_windows())
 		{
@@ -811,6 +816,10 @@ class phodevi_cpu extends phodevi_device_interface
 				$family = $processor_identifier[($x + 1)];
 			}
 		}
+		else if(phodevi::is_macosx())
+		{
+			$family = phodevi_bsd_parser::read_sysctl(array('machdep.cpu.family'));
+		}
 
 		return $family;
 	}
@@ -829,6 +838,10 @@ class phodevi_cpu extends phodevi_device_interface
 			{
 				$model = $processor_identifier[($x + 1)];
 			}
+		}
+		else if(phodevi::is_macosx())
+		{
+			$family = phodevi_bsd_parser::read_sysctl(array('machdep.cpu.model'));
 		}
 
 		return $model;

--- a/pts-core/objects/phodevi/parsers/phodevi_bsd_parser.php
+++ b/pts-core/objects/phodevi/parsers/phodevi_bsd_parser.php
@@ -25,7 +25,7 @@ class phodevi_bsd_parser
 {
 	public static function read_sysctl($desc)
 	{
-		// Read sysctl, used by *BSDs
+		// Read sysctl, used by *BSDs and macOS
 		$info = false;
 
 		if(pts_client::executable_in_path('sysctl'))

--- a/pts-core/objects/phodevi/parsers/phodevi_osx_parser.php
+++ b/pts-core/objects/phodevi/parsers/phodevi_osx_parser.php
@@ -23,14 +23,25 @@
 
 class phodevi_osx_parser
 {
+	public static $cached_results = array();
+
+	private static function run_command_to_lines_cached($command)
+	{
+		if(!$array_key_exists($command, self::$cached_results))
+		{
+			$info = trim(shell_exec($command));
+			self::$cached_results[$command] = explode("\n", $info);
+		}
+
+		return self::$cached_results[$command];
+	}
 	public static function read_osx_system_profiler($data_type, $object, $multiple_objects = false, $ignore_values = array())
 	{
 		$value = ($multiple_objects ? array() : false);
 
 		if(pts_client::executable_in_path('system_profiler'))
 		{
-			$info = trim(shell_exec('system_profiler ' . $data_type . ' 2>&1'));
-			$lines = explode("\n", $info);
+			$lines = self::run_command_to_lines_cached('system_profiler ' . $data_type . ' 2>&1');
 
 			for($i = 0; $i < count($lines) && ($value == false || $multiple_objects); $i++)
 			{

--- a/pts-core/objects/phodevi/parsers/phodevi_osx_parser.php
+++ b/pts-core/objects/phodevi/parsers/phodevi_osx_parser.php
@@ -25,9 +25,9 @@ class phodevi_osx_parser
 {
 	public static $cached_results = array();
 
-	private static function run_command_to_lines_cached($command)
+	private static function run_command_to_lines_cached($command, $cache)
 	{
-		if(!$array_key_exists($command, self::$cached_results))
+		if(!$cache || !$array_key_exists($command, self::$cached_results))
 		{
 			$info = trim(shell_exec($command));
 			self::$cached_results[$command] = explode("\n", $info);
@@ -35,13 +35,13 @@ class phodevi_osx_parser
 
 		return self::$cached_results[$command];
 	}
-	public static function read_osx_system_profiler($data_type, $object, $multiple_objects = false, $ignore_values = array())
+	public static function read_osx_system_profiler($data_type, $object, $multiple_objects = false, $ignore_values = array(), $cache = true)
 	{
 		$value = ($multiple_objects ? array() : false);
 
 		if(pts_client::executable_in_path('system_profiler'))
 		{
-			$lines = self::run_command_to_lines_cached('system_profiler ' . $data_type . ' 2>&1');
+			$lines = self::run_command_to_lines_cached('system_profiler ' . $data_type . ' 2>&1', $cache);
 
 			for($i = 0; $i < count($lines) && ($value == false || $multiple_objects); $i++)
 			{

--- a/pts-core/objects/phodevi/sensors/cpu_freq.php
+++ b/pts-core/objects/phodevi/sensors/cpu_freq.php
@@ -137,7 +137,7 @@ class cpu_freq extends phodevi_sensor
 	}
 	private function cpu_freq_macosx()
 	{
-		$info = phodevi_osx_parser::read_osx_system_profiler('SPHardwareDataType', 'ProcessorSpeed');
+		$info = phodevi_osx_parser::read_osx_system_profiler('SPHardwareDataType', 'ProcessorSpeed', false, array(), false);
 
 		if(($cut_point = strpos($info, ' ')) > 0)
 		{

--- a/pts-core/objects/phodevi/sensors/sys_power.php
+++ b/pts-core/objects/phodevi/sensors/sys_power.php
@@ -224,7 +224,7 @@ class sys_power extends phodevi_sensor
 		}
 		else if(phodevi::is_macosx())
 		{
-			$current = abs(phodevi_osx_parser::read_osx_system_profiler('SPPowerDataType', 'Amperage')); // in mA
+			$current = abs(phodevi_osx_parser::read_osx_system_profiler('SPPowerDataType', 'Amperage', false, array(), false)); // in mA
 		}
 
 		return $current;
@@ -298,8 +298,8 @@ class sys_power extends phodevi_sensor
 		}
 		else if(phodevi::is_macosx())
 		{
-			$amperage = abs(phodevi_osx_parser::read_osx_system_profiler('SPPowerDataType', 'Amperage')); // in mA
-			$voltage = phodevi_osx_parser::read_osx_system_profiler('SPPowerDataType', 'Voltage'); // in mV
+			$amperage = phodevi_osx_parser::read_osx_system_profiler('SPPowerDataType', 'Amperage', false, array(), false); // in mA
+			$voltage = phodevi_osx_parser::read_osx_system_profiler('SPPowerDataType', 'Voltage'); // in mV (no need to uncache since we just ran it)
 
 			if($amperage > 0 && $voltage > 0)
 			{


### PR DESCRIPTION
The SPHardwareDataType system profiler query only returns a
marketing string that has no use for us. Use something else when possible.

I was thinking about doing something similar with the flags
(machdep.cpu.features), but the current code is toooo Linux-centric to
play with.