### PR TITLE
compress-zstd: Fix for the zstd benchmark output parse

### DIFF
--- a/ob-cache/test-profiles/pts/compress-zstd-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/compress-zstd-1.2.0/install.sh
@@ -9,5 +9,6 @@ cd ~
 cat > compress-zstd <<EOT
 #!/bin/sh
 ./zstd-1.4.5/zstd -T\$NUM_CPU_CORES \$@ ubuntu-18.04.3-desktop-amd64.iso > \$LOG_FILE 2>&1
+sed -i -e "s/\r/\n/g" \$LOG_FILE
 EOT
 chmod +x compress-zstd


### PR DESCRIPTION
This is the fix for the zstd benchmark output parse. Due to the "\r" character in the output, PTS couldn't get the correct result as expected. Here is an example of the test output:
```
Zstd Compression 1.4.5:
    pts/compress-zstd-1.2.0 [Compression Level: 3]
    Test 1 of 1
    Estimated Trial Run Count:    3
    Estimated Time To Completion: 6 Minutes [20:24 PDT]
        Started Run 1 @ 20:18:29
        Started Run 2 @ 20:19:10
        Started Run 3 @ 20:19:49

    Compression Level: 3:
        2803
        2811.3
        2776.5

    Average: 2796.9 MB/s
    Deviation: 0.65%
```
The actual output log of zstd is as below:
```
Loading ubuntu-18.04.3-desktop-amd64.iso...       ^M                                                                      ^M |-desktop-amd64.iso :2082816000 ->^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2803.0 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2803.0 MB/s ,6511.0 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2812.0 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2812.0 MB/s ,6511.0 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2839.4 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2839.4 MB/s ,6511.8 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.3 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.3 MB/s ,6523.4 MB/s ^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.3 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.3 MB/s ,6523.4 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.4 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.4 MB/s ,6523.4 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.4 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.4 MB/s ,6523.4 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.4 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2842.4 MB/s ,6527.2 MB/s ^M 3#	
Loading ubuntu-18.04.3-desktop-amd64.iso...       ^M                                                                      ^M |-desktop-amd64.iso :2082816000 ->^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2776.5 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2776.5 MB/s ,6514.0 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.7 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.7 MB/s ,6514.0 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.8 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.8 MB/s ,6518.9 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.8 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.8 MB/s ,6529.8 MB/s ^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.8 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2809.8 MB/s ,6529.8 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2817.3 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2817.3 MB/s ,6529.8 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2819.3 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2819.3 MB/s ,6532.9 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2819.3 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2819.3 MB/s ,6532.9 MB/s ^M 3#
Loading ubuntu-18.04.3-desktop-amd64.iso...       ^M                                                                      ^M |-desktop-amd64.iso :2082816000 ->^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2811.3 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2811.3 MB/s ,6501.1 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2821.7 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2821.7 MB/s ,6509.9 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2821.7 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2821.7 MB/s ,6509.9 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s ,6509.9 MB/s ^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s ,6516.6 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s ,6516.6 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s ,6516.6 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2830.0 MB/s ,6518.4 MB/s ^M 3#	
```

PTS just get the first time printed output, which is not stable and low, especially for a system with many cores.
This fix will replace the "\r" with "\n" and make PTS get the last output. 
Here is the output after the fix:
```
Zstd Compression 1.4.5:
    pts/compress-zstd-1.2.0 [Compression Level: 3]
    Test 1 of 1
    Estimated Trial Run Count:    3
    Estimated Time To Completion: 6 Minutes [20:44 PDT]
        Started Run 1 @ 20:38:21
        Started Run 2 @ 20:39:01
        Started Run 3 @ 20:39:41

    Compression Level: 3:
        2860.6
        2864.1
        2866.1

    Average: 2863.6 MB/s
    Deviation: 0.10%
```
Log file:
```
Loading ubuntu-18.04.3-desktop-amd64.iso...       ^M                                                                      ^M |-desktop-amd64.iso :2082816000 ->^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2824.8 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2824.8 MB/s ,6524.9 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2846.8 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2846.8 MB/s ,6524.9 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2857.6 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2857.6 MB/s ,6540.8 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s ,6540.8 MB/s ^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s ,6540.8 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s ,6540.8 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s ,6540.8 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2860.6 MB/s ,6544.2 MB/s ^M 3#
Loading ubuntu-18.04.3-desktop-amd64.iso...       ^M                                                                      ^M |-desktop-amd64.iso :2082816000 ->^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2839.5 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2839.5 MB/s ,6574.1 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s ,6574.1 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s ,6574.1 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s ,6574.1 MB/s ^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s ,6574.1 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s ,6574.1 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2862.3 MB/s ,6574.1 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2864.1 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2864.1 MB/s ,6574.1 MB/s ^M 3#
Loading ubuntu-18.04.3-desktop-amd64.iso...       ^M                                                                      ^M |-desktop-amd64.iso :2082816000 ->^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2849.0 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2849.0 MB/s ,6554.6 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2864.1 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2864.1 MB/s ,6554.6 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s ,6554.6 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s ,6556.8 MB/s ^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s^M |-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s ,6556.8 MB/s ^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s^M /-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s ,6556.8 MB/s ^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s^M =-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s ,6556.8 MB/s ^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s^M \-desktop-amd64.iso :2082816000 ->2063222758 (1.009),2866.1 MB/s ,6556.8 MB/s ^M 3#
```
