### PR TITLE
Performance fix of systemd daemon result-viewer

### DIFF
--- a/pts-core/commands/start_result_viewer.php
+++ b/pts-core/commands/start_result_viewer.php
@@ -50,7 +50,7 @@ class start_result_viewer implements pts_option_interface
 			echo PHP_EOL . 'Press CTRL^C when done accessing the viewer to end the process...';
 			while(true)
 			{
-				pts_user_io::read_user_input();
+				sleep(60);
 			}
                 }
 	}


### PR DESCRIPTION
Hello It's me again. I discovered that when the result-viewer is running from systemd, It take whole cpu core.

I found that it is caused by waiting for user input in file pts-core/commands/start_result_viewer.php 

It seems that is caused by that systemd doesn't assign stdin/out pipe for child processes that are executed by the parent command (start-result-viewer daemon) and the while(true) loop running without waiting for input (because there is no stdin pipe).

I solved it by replacing the user input waiting with sleep waiting and now it works ok.

So it would be nice to merge this fix. 

Thanks!