### PR TITLE
Fixed typo - 10.2.0 was released (re-released?) 5 January 2021, not 5…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 PHORONIX TEST SUITE CHANGE-LOG
 
 Phoronix Test Suite 10.2.0
-5 January 2020
+5 January 2021
 
 pts-core: PHP8 detection improvements
 pts-core: For estimated run time, avoid over-calculating time if test has no options but multiple outputs


### PR DESCRIPTION
… January 2020