### PR TITLE
Fix stray bracket

### DIFF
--- a/pts-core/external-test-dependencies/scripts/install-debian-packages.sh
+++ b/pts-core/external-test-dependencies/scripts/install-debian-packages.sh
@@ -9,7 +9,7 @@ if [ -x /usr/bin/aptitude ]; then
 	# aptitude is nice since it doesn't fail if a non-existant package is hit
 	# See: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=503215
 	su -c "aptitude -y install $*"
-elif [ `whoami` = "admin" ] || [ -f /dev/.cros_milestone ]] && [ -x /usr/bin/sudo ]; then
+elif [ `whoami` = "admin" ] || [ -f /dev/.cros_milestone ] && [ -x /usr/bin/sudo ]; then
 	# Amazon EC2 is admin user, sudo works
 	# crostini (Chrome OS) also defaults to sudo https://chromeos.dev/en/linux/setup#installing-linux-apps-and-packages
 	sudo apt-get -y --ignore-missing install $*


### PR DESCRIPTION
Fixed stray bracket introduced #495 

Tested, worked for me

```
> phoronix-test-suite run pts/smallpt
...
The following dependencies are needed and will be installed: 

- build-essential
- autoconf
- mesa-utils
- vulkan-utils
- unzip
- apt-file

This process may take several minutes.
debconf: delaying package configuration, since apt-utils is not installed
Reading package lists...
Building dependency tree...
Reading state information...
...
Setting up autoconf (2.69-11) ...
Setting up automake (1:1.16.1-4) ...
update-alternatives: using /usr/bin/automake-1.16 to provide /usr/bin/automake (automake) in auto mode
Processing triggers for man-db (2.8.5-2) ...
Processing triggers for mime-support (3.62) ...

Phoronix Test Suite v10.2.0

    To Install:    pts/smallpt-1.2.1
```

