### PR TITLE
change of projecturl for NWChem

### DIFF
--- a/ob-cache/test-profiles/pts/nwchem-1.0.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/nwchem-1.0.0/test-definition.xml
@@ -19,7 +19,7 @@
     <Status>Verified</Status>
     <ExternalDependencies>build-utilities, openmpi-development, fortran-compiler, blas-development, lapack-development, atlas-development, tcl</ExternalDependencies>
     <EnvironmentSize>1100</EnvironmentSize>
-    <ProjectURL>http://www.nwchem-sw.org/</ProjectURL>
+    <ProjectURL>https://nwchemgit.github.io/</ProjectURL>
     <InternalTags>SMP, MPI</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
   </TestProfile>

--- a/ob-cache/test-profiles/pts/nwchem-1.1.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/nwchem-1.1.0/test-definition.xml
@@ -19,7 +19,7 @@
     <Status>Verified</Status>
     <ExternalDependencies>build-utilities, openmpi-development, fortran-compiler, blas-development, lapack-development, atlas-development, tcl</ExternalDependencies>
     <EnvironmentSize>1100</EnvironmentSize>
-    <ProjectURL>http://www.nwchem-sw.org/</ProjectURL>
+    <ProjectURL>https://nwchemgit.github.io/</ProjectURL>
     <InternalTags>SMP, MPI</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
   </TestProfile>


### PR DESCRIPTION
Please use the new NWChem website since the old one has been taken over by cyber-squatters.