### PR TITLE
Small changes for Stockfish benchmark

### DIFF
--- a/ob-cache/test-profiles/pts/stockfish-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/stockfish-1.2.0/install.sh
@@ -5,7 +5,7 @@ cd Stockfish-sf_12/src/
 
 if [ $OS_ARCH = "x86_64" ]
 then
-	ARCH=x86-64-modern
+	ARCH=x86-64-avx2
 elif [ $OS_ARCH = "ppc64" ]
 then
 	ARCH=ppc-64

--- a/ob-cache/test-profiles/pts/stockfish-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/stockfish-1.2.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>Stockfish</Title>
     <AppVersion>12</AppVersion>
-    <Description>This is a test of Stockfish, an advanced C++11 chess benchmark that can scale up to 128 CPU cores.</Description>
+    <Description>This is a test of Stockfish, an advanced C++11 chess benchmark that can scale up to 512 CPU cores.</Description>
     <ResultScale>Nodes Per Second</ResultScale>
     <Proportion>HIB</Proportion>
     <SubTitle>Total Time</SubTitle>


### PR DESCRIPTION
linux and windows did not target the same architecture.
Fix by using avx2 instructions also for linux (won't work for older CPUs)

Correctly mention the benchmark scales to 512 threads.

NB: project has released SF13 with improved code for modern chips.