### PR TITLE
pts-core: Add debug commands & improve logging

### DIFF
--- a/pts-core/modules/phoromatic.php
+++ b/pts-core/modules/phoromatic.php
@@ -581,7 +581,12 @@ class phoromatic extends pts_module_interface
 					}
 				}
 
-				switch(isset($json['phoromatic']['task']) ? $json['phoromatic']['task'] : null)
+				$task = isset($json['phoromatic']['task']) ? $json['phoromatic']['task'] : null;
+
+				if ($task != 'idle')
+					pts_client::$pts_logger->log("Received " . $json['phoromatic']['task'] . " command");
+
+				switch($task)
 				{
 					case 'install':
 						phoromatic::update_system_status('Installing Tests');

--- a/pts-core/objects/client/pts_logger.php
+++ b/pts-core/objects/client/pts_logger.php
@@ -75,8 +75,17 @@ class pts_logger
 		if($this->log_file == null)
 			return;
 
+		$traces = debug_backtrace();
+
+		if (isset($traces[0]))
+    		{
+		        $caller = $traces[1]['function'];
+		        $line = $traces[0]['line'];
+		        $file = basename($traces[0]['file']);
+		}
+
 		$message = pts_user_io::strip_ansi_escape_sequences($message);
-		file_put_contents($this->log_file, ($date_prefix ? '[' . date('M ' . str_pad(date('j'), 2, ' ', STR_PAD_LEFT) . ' H:i:s Y') . '] ' : null) . $message . PHP_EOL, FILE_APPEND);
+		file_put_contents($this->log_file, ($date_prefix ? '[' . date('Y-m-d\TH:i:sO') . '] ' : null) . "[" . $caller . "(". $file . ":" . $line . ")] " . $message . PHP_EOL, FILE_APPEND);
 	}
 	public function get_log_file_size()
 	{


### PR DESCRIPTION
Adds logging of the non-idle commands coming from the
Phoromatic Server.

Adjust log date to include timedate by moving to ISO8601 format date
Include backtrace information to identify function, file and line for
log messages