### PR TITLE
Add vulkan-headers for Arch Linux

### DIFF
--- a/pts-core/external-test-dependencies/xml/arch-packages.xml
+++ b/pts-core/external-test-dependencies/xml/arch-packages.xml
@@ -23,7 +23,7 @@
 		</Package>
 		<Package>
 			<GenericName>vulkan-development</GenericName>
-			<PackageName>vulkan-icd-loader vulkan-tools</PackageName>
+			<PackageName>vulkan-headers vulkan-icd-loader vulkan-tools</PackageName>
 		</Package>
 		<Package>
 			<GenericName>pcre</GenericName>


### PR DESCRIPTION
The PTS warned that Vulkan wasn't installed until I installed the 'vulkan-headers' package.