### PR TITLE
Add root lock check for Arch Linux

### DIFF
--- a/pts-core/external-test-dependencies/scripts/install-arch-packages.sh
+++ b/pts-core/external-test-dependencies/scripts/install-arch-packages.sh
@@ -2,6 +2,13 @@
 
 # Arch package installation
 
-echo "Please enter your root password below:" 1>&2
-su root -c "pacman -Sy --noconfirm --needed --asdeps $*"
+echo "Checking for root availability, please enter your sudo passowrd below:" 1>&2
+if sudo passwd -S root | grep -q 'L' 1>&2; then
+    echo "Root account locked, using sudo to install packages" 1>&2
+    #echo "Please enter your sudo password below:" 1>&2
+    sudo pacman -Sy --noconfirm --needed --asdeps $*
+else
+    echo "Root account not locked, please enter your root password below:" 1>&2
+    su root -c "pacman -Sy --noconfirm --needed --asdeps $*"
+fi
 exit


### PR DESCRIPTION
The 'arch-install' installer includes an option to lock out the root user and use a sudo only system. When that's the case the PTS fails to install Arch Linux packages. This uses sudo passwd -S to check if the root account is locked and runs pacman with sudo instead of su -c if true.