### PR TITLE
NPB -- Strip extra version info from CCVERSION and fix typo

### DIFF
--- a/ob-cache/test-profiles/pts/npb-1.4.4/install.sh
+++ b/ob-cache/test-profiles/pts/npb-1.4.4/install.sh
@@ -59,7 +59,7 @@ then
 else
           CFLAGS="$CFLAGS_OVERRIDE"
 fi
-CCVERSION=`cc -dumpversion`
+CCVERSION=`cc -dumpversion | sed "s/\..*//"`
 echo "Compiler Version is $CCVERSION"
 if [ "$CCVERSION" -gt 9 ]; then
     CFLAGS="$CFLAGS -fallow-argument-mismatch"
@@ -88,7 +88,7 @@ WTIME  = wtime.c
 " > NPB3.4.1/NPB3.4-MPI/config/make.def
 
 # Copy over OpenMP make for when using that...
-cp NPB3.4.1/NPB3.4-MPI/config/make.def NPB3.4/NPB3.4-OMP/config/make.def
+cp NPB3.4.1/NPB3.4-MPI/config/make.def NPB3.4.1/NPB3.4-OMP/config/make.def
 
 cd ~/NPB3.4.1/NPB3.4-MPI/
 


### PR DESCRIPTION
CCVERSION reports 11.1.0 on my system which breaks the -gt numerical comparison. I used sed to strip everything after the first detected decimal to only report the major version of the compiler.  

A few lines below that I saw a typo in the cp command and fixed it.