### PR TITLE
Update a dependency link for Windows

### DIFF
--- a/ob-cache/test-profiles/pts/dav1d-1.9.0/downloads.xml
+++ b/ob-cache/test-profiles/pts/dav1d-1.9.0/downloads.xml
@@ -47,7 +47,7 @@
       <FileSize>288122748</FileSize>
     </Package>
     <Package>
-      <URL>http://github.com/advancedfx/ffmpeg.zeranoe.com-builds-mirror/raw/main/ffmpeg-4.2.1-win64-static.zip</URL>
+      <URL>https://www.videohelp.com/download/ffmpeg-4.2.1-win64-static.zip</URL>
       <MD5>ae19c3a0006e4f1f34c5f3910bfb3635</MD5>
       <SHA256>d2af87bbb867bc83c070f3c1a980daaed35c37b02ca82cc2886e8743232886ff</SHA256>
       <FileName>ffmpeg-4.2.1-win64-static.zip</FileName>


### PR DESCRIPTION
File from the old link has 1b and checksum is failing.