### PR TITLE
Update ONNX Runtime perf test

### DIFF
--- a/ob-cache/test-profiles/pts/onnx-1.1.0/downloads.xml
+++ b/ob-cache/test-profiles/pts/onnx-1.1.0/downloads.xml
@@ -26,11 +26,5 @@
       <FileSize>1815286</FileSize>
       <Optional>TRUE</Optional>
     </Package>
-    <Package>
-      <URL>https://github.com/onnx/models/raw/master/text/machine_comprehension/bert-squad/model/bertsquad-10.tar.gz</URL>
-      <FileName>bertsquad-10.tar.gz</FileName>
-      <FileSize>403081800</FileSize>
-      <Optional>TRUE</Optional>
-    </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/onnx-1.1.0/install.sh
+++ b/ob-cache/test-profiles/pts/onnx-1.1.0/install.sh
@@ -3,8 +3,8 @@
 rm -rf onnxruntime
 git clone https://github.com/microsoft/onnxruntime
 cd onnxruntime
-git checkout v1.8.2
-./build.sh --config Release --build_shared_lib --parallel --use_openmp --skip_tests
+git checkout v1.9.1
+./build.sh --config Release --build_shared_lib --parallel --skip_tests --enable_lto --cmake_extra_defines onnxruntime_BUILD_FOR_NATIVE_MACHINE=ON
 echo $? > ~/install-exit-status
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -17,10 +17,10 @@ tar -xf yolov4.tar.gz
 tar -xf fcn-resnet101-11.tar.gz
 tar -xf shufflenet-v2-10.tar.gz
 tar -xf super-resolution-10.tar.gz
-tar -xf bertsquad-10.tar.gz
+
 
 echo "#!/bin/bash
 
-OMP_NUM_THREADS=\$NUM_CPU_CORES ./onnxruntime/build/Linux/Release/onnxruntime_perf_test \$@ > \$LOG_FILE 2>&1
+./onnxruntime/build/Linux/Release/onnxruntime_perf_test \$@ > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status" > onnx
 chmod +x onnx

--- a/ob-cache/test-profiles/pts/onnx-1.1.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/onnx-1.1.0/test-definition.xml
@@ -21,7 +21,7 @@
     <EnvironmentSize>3200</EnvironmentSize>
     <ProjectURL>https://www.onnxruntime.ai/</ProjectURL>
     <RepositoryURL>https://github.com/microsoft/onnxruntime</RepositoryURL>
-    <InternalTags>OpenMP, SMP</InternalTags>
+    <InternalTags>SMP</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
   </TestProfile>
   <TestSettings>
@@ -60,7 +60,7 @@
       <ArgumentPrefix>-e </ArgumentPrefix>
       <Menu>
         <Entry>
-          <Name>OpenMP CPU</Name>
+          <Name>CPU</Name>
           <Value>cpu</Value>
         </Entry>
       </Menu>


### PR DESCRIPTION
1. Update onnx runtime to the latest version: 1.9.1
2. Remove openmp
3. Remove bertsquad model since it doesn't work with the new version. 

