### PR TITLE
[pts-core] Result export by file should use a generic name

### DIFF
--- a/pts-core/commands/result_file_to_pdf.php
+++ b/pts-core/commands/result_file_to_pdf.php
@@ -45,7 +45,7 @@ class result_file_to_pdf implements pts_option_interface
 		pts_client::generate_result_file_graphs($r[0], $tdir);
 
 		$result_file = new pts_result_file($r[0]);
-		$pdf_file = pts_core::user_home_directory() . $r[0] . '.pdf';
+		$pdf_file = tempnam(pts_core::user_home_directory(), 'pdf');
 		$pdf_output = pts_result_file_output::result_file_to_pdf($result_file, $pdf_file, 'F');
 		$result_output = file_get_contents($pdf_file);
 		unlink($pdf_file);

--- a/pts-core/objects/client/pts_client.php
+++ b/pts-core/objects/client/pts_client.php
@@ -2569,6 +2569,9 @@ class pts_client
 	{
 		if(($output_file = getenv('OUTPUT_FILE')) == false)
 		{
+			if(file_exists($title)) {
+				$title = "test-result";
+			}
 			if(($output_dir = getenv('OUTPUT_DIR')) == false || !is_dir($output_dir))
 			{
 				$output_dir = pts_core::user_home_directory();


### PR DESCRIPTION
Use a generic name for export when referring to a test file via
filename vs assuming that the parameter is a test result identifier.