### PR TITLE
perf_tips: Improve governor tip 

### DIFF
--- a/pts-core/modules/perf_tips.php
+++ b/pts-core/modules/perf_tips.php
@@ -122,7 +122,7 @@ class perf_tips extends pts_module_interface
 
 			if(phodevi::is_linux() && stripos($cpu_scaling_governor, 'performance') === false)
 			{
-				$perf_tips[] = new pts_perf_tip_msg('The powersave CPU scaling governor is currently in use. It\'s possible to obtain greater performance if using the performance governor.', 'echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor', 'https://openbenchmarking.org/result/1706268-TR-CPUGOVERN32');
+				$perf_tips[] = new pts_perf_tip_msg('The CPU scaling governor is currently not set to performance. It\'s possible to obtain greater performance if using the performance governor.', 'echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor', 'https://openbenchmarking.org/result/1706268-TR-CPUGOVERN32');
 			}
 
 			if(is_file('/sys/devices/system/cpu/cpufreq/boost'))

--- a/pts-core/modules/perf_tips.php
+++ b/pts-core/modules/perf_tips.php
@@ -120,7 +120,8 @@ class perf_tips extends pts_module_interface
 			// BELOW ARE CHECKS TO MAKE IF WANTING TO SHOW FOR 'Processor' OR 'System' TESTS
 			$cpu_scaling_governor = phodevi::read_property('cpu', 'scaling-governor');
 
-			if(phodevi::is_linux() && stripos($cpu_scaling_governor, 'performance') === false)
+			// Linux: Check if scaling governor is available and if it is set to performance
+			if(phodevi::is_linux() && $cpu_scaling_governor && stripos($cpu_scaling_governor, 'performance') === false)
 			{
 				$perf_tips[] = new pts_perf_tip_msg('The CPU scaling governor is currently not set to performance. It\'s possible to obtain greater performance if using the performance governor.', 'echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor', 'https://openbenchmarking.org/result/1706268-TR-CPUGOVERN32');
 			}


### PR DESCRIPTION
Reword the message to avoid confusion with the "powersave" governor
and only print the message if a governor is actually available.