### PR TITLE
Automate building Docker container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+deploy/**
+.git/**
+Dockerfile
+.devcontainer/**
+.github/**

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,52 @@
+name: Docker Builds
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker Metadata
+        id: docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+          tags: |
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=edge
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,7 +21,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
@@ -38,8 +38,16 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -50,3 +58,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,9 +17,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Docker Metadata
-        id: docker_meta
-        uses: docker/metadata-action@v3
+      - name: Docker Metadata (light target)
+        id: metadata_light
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          flavor: |
+            suffix=-light,onlatest=true
+          tags: |
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=edge
+
+      - name: Docker Metadata (full target)
+        id: metadata
+        uses: docker/metadata-action@v3.6.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
@@ -49,16 +62,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build and push
+      - name: Build and push (light target)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          target: light
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata_light.outputs.tags }}
+          labels: ${{ steps.metadata_light.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      # building the full version could be done in a separate workflow,
+      # but using the same instance allows reusing the light target as a base
+      - name: Build and push (full target)
         uses: docker/build-push-action@v2
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
         # Temp fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04 as light
+
+LABEL org.opencontainers.image.authors="Phoronix Media <commercial@phoronix-test-suite.com>"
+
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+  apt-file\
+  apt-utils\
+  git-core\
+  php-cli\
+  php-xml\
+  sudo\
+  unzip\
+  && rm -rf /var/lib/apt/lists/*
+
+
+WORKDIR /app/
+
+# copy in files
+COPY . /app/
+
+RUN ./phoronix-test-suite make-openbenchmarking-cache lean \
+  && rm -f /var/lib/phoronix-test-suite/core.pt2so
+
+CMD ["./phoronix-test-suite", "shell"]
+
+
+FROM light as full
+
+# install extra packages commonly used by tests
+RUN apt-get update && apt-get install -y \
+  build-essential\
+  autoconf\
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR Adds a Dockerfile to the application to allow for easier building of containers. The existing deploy script does most of the setup on the host rather than within the container. This forces the host to have the required tools and files rather than having these requirements solely within the container. This also meant that the container had to be the same architecture (x86, x86_64, arm, etc) as the building host.
The added Dockerfile also contains two [build stages](https://docs.docker.com/develop/develop-images/multistage-build/), one which installs the minimal dependencies for pts to run ("light" version) and one which installs packages required by most tests ("full" version). The default when doing a `docker build` is the full version, but adding `--target light` will produce the minimal light build. The full version strictly builds off of the light version, so pulling the full version also pulls the light version, and pulling the light version pulls a significant portion of the full version.

This PR additionally adds a GitHub Actions workflow to automatically build and push the containers. It activates on any pushes to the master branch as well as any pushed version tags (tags matching "v*"). The master branch builds will be tagged as "edge" and "edge-light". Builds of version tags will be tagged with major, major and minor, and major and minor and patch (e.g. a tag of "v1.2.3" will create a build with tags of "1", "1.2", and "1.2.3") as well as the "latest" tag. An additional image will be created for the light version with the same tags as the full version but with "-light" appended (e.g. "1-light", "1.2-light", "1.2.3-light", and "latest-light").
These builds are completed for multiple architectures (currently amd64, arm/v7, arm64, and riscv64) with the different versions of the same code combined together within the manifest. This allows a user on any platform to pull the tag "1.2.3" and will select the correct image for their architecture.

This PR currently pushes containers to the GitHub Container Registry (ghcr.io). This simplifies authenticating with the registry (automatic rather than requiring setup like Docker Hub) and uses the repo name as the container name ("ghcr.io/phoronix-test-suite/phoronix-test-suite"). However, this name can easily be changed and another container registry used or added.

TL;DR - adds Dockerfile and auto (multi-architecture) builds using GH Actions, pushing to GHCR using the same name as the repo.