### PR TITLE
pts-core:  Fix bug converting from sha1 to base 36 in compute_pprid

### DIFF
--- a/pts-core/objects/phoromatic/phoromatic_server.php
+++ b/pts-core/objects/phoromatic/phoromatic_server.php
@@ -522,7 +522,7 @@ class phoromatic_server
 	}
 	public static function compute_pprid($account_id, $system_id, $upload_time, $xml_upload_hash)
 	{
-		return base_convert(sha1($account_id . ' ' . $system_id . ' ' . $xml_upload_hash . ' ' . $upload_time), 10, 36);
+		return base_convert(sha1($account_id . ' ' . $system_id . ' ' . $xml_upload_hash . ' ' . $upload_time), 16, 36);
 	}
 	public static function system_id_to_name($system_id, $aid = false)
 	{


### PR DESCRIPTION
Longstanding bug when converting the base 16 sha1 to base 36 encoding for pprid.  Recent versions of php seem to be complaining about this to stdout.  This fixes a regression in log file uploading for phoromatic.