### PR TITLE
pts-core: Include alternate path for system-logs for result viewer

### DIFF
--- a/pts-core/objects/pts_result_file_system.php
+++ b/pts-core/objects/pts_result_file_system.php
@@ -222,6 +222,7 @@ class pts_result_file_system
 				if($res === true)
 				{
 					$possible_log_paths = array('system-logs/' . $this->get_identifier() . '/');
+					$possible_log_paths[] = 'system-logs/' . pts_strings::simplify_string_for_file_handling($this->get_identifier()) . '/';
 
 					if($this->get_identifier() != $this->get_original_identifier())
 					{


### PR DESCRIPTION
When uploading to Phoromatic, the system logs are staged after simplifying
the identifier with pts_strings::simplify_string_for_file_handling().

Closes #577