### PR TITLE
Windows: Include update build revision (UBR) in kernel version

### DIFF
--- a/pts-core/objects/phodevi/components/phodevi_system.php
+++ b/pts-core/objects/phodevi/components/phodevi_system.php
@@ -411,7 +411,7 @@ class phodevi_system extends phodevi_device_interface
 					$fs = 'NTFS';
 				}
 			}
-		}
+		}	
 
 		if(empty($fs))
 		{
@@ -1018,7 +1018,28 @@ class phodevi_system extends phodevi_device_interface
 	}
 	public static function sw_kernel()
 	{
-		return php_uname('r');
+		if(phodevi::is_windows())
+		{
+			// CurrentBuild and CurrentVersion are available since at least NT 4.0
+			// CurrentVersion is frozen at 6.3 (same as Windows 8.1) in Windows 10 & 11
+			$currentBuild = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentBuild) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentBuild).CurrentBuild } Else { $null }"'));
+			$currentVersion = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentVersion) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentVersion).CurrentVersion } Else { $null }"'));
+
+			// Windows 10 & 11 add CurrentMajorVersionNumber, CurrentMinorVersionNumber and UBR
+			$currentMajorVersionNumber = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMajorVersionNumber) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMajorVersionNumber).CurrentMajorVersionNumber } Else { $null }"'));
+			$currentMinorVersionNumber = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMinorVersionNumber) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMinorVersionNumber).CurrentMinorVersionNumber } Else { $null }"'));
+			$updateBuildRevision = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' UBR) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' UBR).UBR } Else { $null }"'));
+
+			if (!empty($currentMajorVersionNumber)) {
+				// Windows 10 and later
+				return $currentMajorVersionNumber . '.' . $currentMinorVersionNumber . '.' . $currentBuild . '.' . $updateBuildRevision;
+			} else {
+				// Windows 8.1 and earlier
+				return $currentVersion . '.' . $currentBuild;
+			}
+		} else {
+			return php_uname('r');
+		}
 	}
 	public static function sw_kernel_parameters()
 	{

--- a/pts-core/objects/phodevi/components/phodevi_system.php
+++ b/pts-core/objects/phodevi/components/phodevi_system.php
@@ -1022,20 +1022,20 @@ class phodevi_system extends phodevi_device_interface
 		{
 			// CurrentBuild and CurrentVersion are available since at least NT 4.0
 			// CurrentVersion is frozen at 6.3 (same as Windows 8.1) in Windows 10 & 11
-			$currentBuild = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentBuild) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentBuild).CurrentBuild } Else { $null }"'));
-			$currentVersion = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentVersion) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentVersion).CurrentVersion } Else { $null }"'));
+			$current_build = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentBuild) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentBuild).CurrentBuild } Else { $null }"'));
+			$current_version = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentVersion) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentVersion).CurrentVersion } Else { $null }"'));
 
 			// Windows 10 & 11 add CurrentMajorVersionNumber, CurrentMinorVersionNumber and UBR
-			$currentMajorVersionNumber = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMajorVersionNumber) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMajorVersionNumber).CurrentMajorVersionNumber } Else { $null }"'));
-			$currentMinorVersionNumber = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMinorVersionNumber) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMinorVersionNumber).CurrentMinorVersionNumber } Else { $null }"'));
-			$updateBuildRevision = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' UBR) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' UBR).UBR } Else { $null }"'));
+			$current_major_version_number = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMajorVersionNumber) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMajorVersionNumber).CurrentMajorVersionNumber } Else { $null }"'));
+			$current_minor_version_number = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMinorVersionNumber) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' CurrentMinorVersionNumber).CurrentMinorVersionNumber } Else { $null }"'));
+			$update_build_revision = trim(shell_exec('powershell "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' UBR) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' UBR).UBR } Else { $null }"'));
 
-			if (!empty($currentMajorVersionNumber)) {
+			if (!empty($current_major_version_number)) {
 				// Windows 10 and later
-				return $currentMajorVersionNumber . '.' . $currentMinorVersionNumber . '.' . $currentBuild . '.' . $updateBuildRevision;
+				return $current_major_version_number . '.' . $current_minor_version_number . '.' . $current_build . '.' . $update_build_revision;
 			} else {
 				// Windows 8.1 and earlier
-				return $currentVersion . '.' . $currentBuild;
+				return $current_version . '.' . $current_build;
 			}
 		} else {
 			return php_uname('r');

--- a/pts-core/objects/phodevi/components/phodevi_system.php
+++ b/pts-core/objects/phodevi/components/phodevi_system.php
@@ -411,7 +411,7 @@ class phodevi_system extends phodevi_device_interface
 					$fs = 'NTFS';
 				}
 			}
-		}	
+		}
 
 		if(empty($fs))
 		{


### PR DESCRIPTION
Query `HKLM\Software\Microsoft\Windows NT\CurrentVersion` for `CurrentMajorVersionNumber`, `CurrentMinorVersionNumber` and `UBR` (Windows 10+) and `CurrentBuild` and `CurrentVersion` (Windows 8.1 and earlier) to populate the kernel version. Particularly with Windows 11, Microsoft has been making changes in regular patches that significantly impact benchmarks, such as the L3 cache fix for AMD processors included in [22000.282](https://support.microsoft.com/en-us/topic/october-21-2021-kb5006746-os-build-22000-282-preview-03190705-0960-4ba4-9ee8-af40bef057d3).

Example Windows 11 kernel version: `10.0.22000.376` (previously `10.0`)
Example Windows 7 kernel version: `6.1.7601` (previously `6.1`)