### PR TITLE
Windows: use known folder for downloads directory

### DIFF
--- a/pts-core/external-test-dependencies/dependency-handlers/microsoft_dependency_handler.php
+++ b/pts-core/external-test-dependencies/dependency-handlers/microsoft_dependency_handler.php
@@ -84,7 +84,7 @@ class microsoft_dependency_handler implements pts_dependency_handler
 		$download_directory = trim(shell_exec('powershell "(New-Object -ComObject Shell.Application).NameSpace(\'shell:Downloads\').Self.Path"'));
 		
 		// Fall back to user profile directory
-		if(empty($download_directory)) {
+		if(empty($download_directory) || !is_dir($download_directory)) {
 			return getenv('USERPROFILE') . '\Downloads\\';
 		}
 

--- a/pts-core/external-test-dependencies/dependency-handlers/microsoft_dependency_handler.php
+++ b/pts-core/external-test-dependencies/dependency-handlers/microsoft_dependency_handler.php
@@ -78,10 +78,17 @@ class microsoft_dependency_handler implements pts_dependency_handler
 		}
 		return $packages_needed;
 	}
-	protected static function file_download_location()
+	public static function file_download_location()
 	{
 		// TODO determine what logic may need to be applied or if to punt it as an option, etc
-		return getenv('USERPROFILE') . '\Downloads\\';
+		$download_directory = trim(shell_exec('powershell "(New-Object -ComObject Shell.Application).NameSpace(\'shell:Downloads\').Self.Path"'));
+		
+		// Fall back to user profile directory
+		if(empty($download_directory)) {
+			return getenv('USERPROFILE') . '\Downloads\\';
+		}
+
+		return pts_strings::add_trailing_slash($download_directory);
 	}
 	protected static function get_cygwin()
 	{

--- a/pts-core/objects/phodevi/components/phodevi_system.php
+++ b/pts-core/objects/phodevi/components/phodevi_system.php
@@ -652,7 +652,7 @@ class phodevi_system extends phodevi_device_interface
 		}
 		else if(phodevi::is_windows())
 		{
-			$mds_tool = getenv('USERPROFILE') . '\Downloads\mdstool-cli.exe';
+			$mds_tool = microsoft_dependency_handler::file_download_location() . 'mdstool-cli.exe';
 			if(is_file($mds_tool))
 			{
 				$mds_output = preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', shell_exec($mds_tool));


### PR DESCRIPTION
Fixes https://github.com/phoronix-test-suite/phoronix-test-suite/issues/465.

Currently `cygwin` etc. are saved to `%USERPROFILE%\Downloads`, but this is a user-configurable path.