### PR TITLE
Add Fedora 35 font

### DIFF
--- a/pts-core/objects/pts_svg_dom_gd.php
+++ b/pts-core/objects/pts_svg_dom_gd.php
@@ -97,6 +97,7 @@ class pts_svg_dom_gd
 				'/usr/share/fonts/truetype/ttf-bitstream-vera/Vera.ttf',
 				'/usr/share/fonts/truetype/freefont/FreeSans.ttf',
 				'/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf',
+				'/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
 				);
 
 				foreach($possible_fonts as $font_file)


### PR DESCRIPTION
On Fedora 35, PTS was unable to find any font, this break PDF export.  
By default Fedora 35 Workstation was ship with DejaVuSans font in the path "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf"  

And it would be possible to add the font RPM (https://fedora.pkgs.org/35/fedora-x86_64/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm.html) as a dependency of the PTS(Fedora) package to make sure it works on any Fedora variants.