### PR TITLE
Fix python-numpy and python-scipy deps for Fedora

### DIFF
--- a/pts-core/external-test-dependencies/xml/fedora-packages.xml
+++ b/pts-core/external-test-dependencies/xml/fedora-packages.xml
@@ -409,5 +409,15 @@
 			<GenericName>libconfigpp</GenericName>
 			<PackageName>libconfig-devel</PackageName>
 		</Package>
+		<Package>
+			<GenericName>python-numpy</GenericName>
+			<PackageName>python3-numpy</PackageName>
+			<FileCheck>/usr/lib*/python*/site-packages/numpy</FileCheck>
+		</Package>
+		<Package>
+			<GenericName>python-scipy</GenericName>
+			<PackageName>python3-scipy</PackageName>
+			<FileCheck>/usr/lib*/python*/site-packages/scipy</FileCheck>
+		</Package>
 	</ExternalDependencies>
 </PhoronixTestSuite>


### PR DESCRIPTION
I'm unsure whether this is the right way to fix the dependency issues, but the PR does solve them in this way.  Unfortunately, the 3 test profiles that depend on these two packages still fail to install properly, at least on RHEL8.  I'll look into that a bit more as time allows.  One of the issues seemed to be Python 3.7 dependency, the other one was a missing downloadable tarball.
