### PR TITLE
fix menu selection sensible to extra space

### DIFF
--- a/pts-core/objects/pts_user_io.php
+++ b/pts-core/objects/pts_user_io.php
@@ -305,6 +305,9 @@ class pts_user_io
 
 			foreach(($allow_multi_select ? pts_strings::comma_explode($select_choice) : array($select_choice)) as $choice)
 			{
+				// sanitize the input against extra spaces (that may be added from the autocompletion)
+				$choice = pts_strings::trim_spaces($choice);
+
 				if(isset($key_index[$choice]))
 				{
 					$select[] = $key_index[$choice];


### PR DESCRIPTION
Menus such as test selection from build-suite are neatly autocompleted,
but the autocompletion (or user error) can insert extra spaces.
They are safe to ignore, moreover no test _should_ rely on these.

Space-sensitivity can induce face-palming behavior where
the user think they provide the exact same string as listed in the menu,
but still encounter a 'no such test exists'-style error