### PR TITLE
phodevi: Remove mode ratio calculation

### DIFF
--- a/pts-core/objects/phodevi/components/phodevi_gpu.php
+++ b/pts-core/objects/phodevi/components/phodevi_gpu.php
@@ -545,8 +545,6 @@ class phodevi_gpu extends phodevi_device_interface
 
 		foreach($available_modes as $mode_index => $mode)
 		{
-			$this_ratio = pts_math::set_precision($mode[0] / $mode[1], 2);
-
 			if($override_check && !in_array($mode, $override_modes))
 			{
 				// Using override modes and this mode is not present


### PR DESCRIPTION
Remove $this_ratio calculation that would cause divide by zero errors.  Does not appear to be used
anywhere and causes errors when the GPU provides only one mode.

Unreproduced failure, but appears safe.