### PR TITLE
fix: system/inkscape to export png

### DIFF
--- a/ob-cache/test-profiles/system/inkscape-1.0.0/install.sh
+++ b/ob-cache/test-profiles/system/inkscape-1.0.0/install.sh
@@ -13,7 +13,7 @@ unzip -o svg-test-files-1.zip
 echo "#!/bin/sh
 for i in *.svg
 do
-	inkscape -z -e output.png \$i
+	inkscape --export-filename=output.png \$i
 	echo \$? > ~/test-exit-status
 done
 


### PR DESCRIPTION
Fix https://github.com/phoronix-test-suite/phoronix-test-suite/issues/643
parameter `-z -e` deprecated for `inkscape >=1.0`.

Result:
```
Inkscape:
    system/inkscape-1.0.0 [Operation: SVG Files To PNG]
    Test 1 of 1
    Estimated Trial Run Count:    3                     
    Estimated Time To Completion: 2 Minutes [13:32 WIB] 
        Started Run 1 @ 13:30:23
        Started Run 2 @ 13:31:01
        Started Run 3 @ 13:31:38

    Operation: SVG Files To PNG:
        33.833
        33.26
        32.828

    Average: 33.307 Seconds
    Deviation: 1.51%
```
