### PR TITLE
fix removal of some results from the viewer when refreshing the page

### DIFF
--- a/pts-core/objects/pts_result_viewer_embed.php
+++ b/pts-core/objects/pts_result_viewer_embed.php
@@ -1245,7 +1245,7 @@ class pts_result_viewer_embed
 	}
 	public static function process_request_to_attributes(&$request, &$result_file, &$extra_attributes)
 	{
-		if(($oss = self::check_request_for_var($request, 'oss')))
+		if(($oss = self::check_request_for_var($request, 'oss')) && gettype($oss) == "string")
 		{
 			$oss = pts_strings::comma_explode($oss);
 			foreach($result_file->get_result_objects() as $i => $result_object)


### PR DESCRIPTION
fix #658 

Hey @michaellarabel , hope you'll consider this contribution which fixes a pretty annoying bug.

#### Some context

when refreshing, the 'Only show results matching....' field
gets evaluated to true because the check_request_for_var function
convert empty strings to _true_. (Why ? I don't know, perhaps other code relies on this behavior)

The value is assumed to be a string by the following code in process_request_to_attribute, and is
implicitely converted from _true_ to '1' somewhere. Maybe in pts_string::comma_explode()

Then, all results which don't match '1' in their description, title, or ID are removed.... so it may not affect the view as well as make all the results disappear !

 Also, the root of the problem (having a function that can return boolean as well as strings) may have effects outside of the scope of this PR. It's worth checking if other calls assume without checking that the value returned by check_request_for_var is always a string.