### PR TITLE
pts-core: Turn specific char to space for possible result line.

### DIFF
--- a/pts-core/objects/pts_test_result_parser.php
+++ b/pts-core/objects/pts_test_result_parser.php
@@ -753,6 +753,9 @@ class pts_test_result_parser
 						if($try_again == false && empty($test_results) && !empty($possible_lines))
 						{
 							$line = array_shift($possible_lines);
+							if($e->get_turn_chars_to_space() != null && $line != null) {
+								$line = str_replace($e->get_turn_chars_to_space(), ' ', $line);
+							}
 							pts_test_result_parser::debug_message('Trying Backup Result Line: ' . $line);
 							$try_again = true;
 						}


### PR DESCRIPTION
Scenario:
Example: One kind of pts/compress-zstd-1.5.0 output: ...
 |-md64-memstick.img :1055957504 -> 716366251 (1.474),6643.6 MB/s ,2792.5 MB/s
 /-md64-memstick.img :1055957504 -> 716366251 (1.474),6643.6 MB/s

Two result templates:
3#desktop-amd64.iso :2082816000 -&gt;2063395360 (1.009) #_RESULT_# MB/s 8080.3 MB/s
3#desktop-amd64.iso :2082816000 -&gt;2063395360 (1.009) 111 MB/s #_RESULT_# MB/s

Problem:
From the last line, result parser gets 6643.6 for the 1st metric, 2nd metric is miss matched. Then it searches backward in last-1 as possible result line, and 2792.5 is expected to be matched. Since existing code doesn't apply "turn chars to space" to last-1(other possible result) line, 2792.5 won't be matched.

This patch resolve above problem by turnng specific char to space for any possible result line.