### PR TITLE
Add live output to shell_exec

### DIFF
--- a/pts-core/objects/client/pts_client.php
+++ b/pts-core/objects/client/pts_client.php
@@ -1763,7 +1763,22 @@ class pts_client
 		}
 		$var_string .= ' ';
 
-		return shell_exec($var_string . $exec);
+		while (@ ob_end_flush());
+
+		$proc = popen($var_string . $exec, 'r');
+		$live_output     = "";
+		$complete_output = "";
+
+		while (!feof($proc))
+		{
+			$live_output     = fread($proc, 4096);
+			$complete_output = $complete_output . $live_output;
+			echo "$live_output";
+			@ flush();
+		}
+
+		pclose($proc);
+		return $complete_output;
 	}
 	public static function get_path()
 	{


### PR DESCRIPTION
It's annoying to wait for the full output after 5-10 minutes to see what is actually happening. Better print the output as it is generated. I don't know if this should be a opt-in or if this breaks other parts of PTS. @michaellarabel?