### PR TITLE
fix: is_proxy_setup() should return 'true' if the proxy is set

### DIFF
--- a/pts-core/commands/network_info.php
+++ b/pts-core/commands/network_info.php
@@ -33,7 +33,7 @@ class network_info implements pts_option_interface
 		$table[] = array('Network MAC: ', phodevi::read_property('network', 'mac-address'));
 		$table[] = array('Wake On LAN: ', implode(' ', pts_network::get_network_wol()));
 
-		if(pts_network::get_network_proxy() != false)
+		if(pts_network::is_proxy_setup())
 		{
 			foreach(pts_network::get_network_proxy() as $item => $val)
 				$table[] = array('Proxy ' . $item, $val);

--- a/pts-core/objects/pts_network.php
+++ b/pts-core/objects/pts_network.php
@@ -326,6 +326,7 @@ class pts_network
 			// e.g. https://www.phoronix.com/forums/forum/phoronix/phoronix-test-suite/905211-problem-network-support-is-needed-to-obtain-package
 			$proxy_address = str_replace(array('http://', 'https://'), '', $proxy_address);
 
+			self::$network_proxy = array();
 			self::$network_proxy['proxy'] = $proxy_address . ':' . $proxy_port;
 			self::$network_proxy['address'] = $proxy_address;
 			self::$network_proxy['port'] = $proxy_port;
@@ -334,6 +335,7 @@ class pts_network
 		}
 		else if(($env_proxy = getenv('http_proxy')) != false && count($env_proxy = pts_strings::colon_explode($env_proxy)) == 2)
 		{
+			self::$network_proxy = array();
 			self::$network_proxy['proxy'] = $env_proxy[0] . ':' . $env_proxy[1];
 			self::$network_proxy['address'] = $env_proxy[0];
 			self::$network_proxy['port'] = $env_proxy[1];

--- a/pts-core/objects/pts_network.php
+++ b/pts-core/objects/pts_network.php
@@ -29,7 +29,7 @@ class pts_network
 
 	public static function is_proxy_setup()
 	{
-		return self::$network_proxy == false;
+		return self::$network_proxy !== false;
 	}
 	public static function get_network_proxy()
 	{


### PR DESCRIPTION
Fix the behavior of pts_network::is_proxy_setup() for #745

- in `network-info` command, use fixed is_proxy_setup() instead of directly comparing return value of get_network_proxy().
- trivial fix: 'Automatic conversion of false to array is deprecated' warning