### PR TITLE
Add environment option for extra architecture support 

### DIFF
--- a/pts-core/objects/phodevi/phodevi.php
+++ b/pts-core/objects/phodevi/phodevi.php
@@ -836,7 +836,7 @@ class phodevi extends phodevi_base
 		{
 			$this_arch = 'x86';
 		}
-		if(!in_array($this_arch, $check_against))
+		if(!in_array($this_arch, $check_against) && !in_array(pts_env::read('HOST_EXTRA_COMPATIBLE_ARCH'), $check_against))
 		{
 			$compatible = false;
 		}

--- a/pts-core/objects/pts_env.php
+++ b/pts-core/objects/pts_env.php
@@ -391,6 +391,13 @@ class pts_env
 			'advertise_in_phoromatic' => true,
 			'onchange' => 'pts_logger::update_log_cli_output_state',
 			),
+		'HOST_EXTRA_COMPATIBLE_ARCH' => array(
+			'description' => 'This option allows to specify additional architecture support from host machine to being able to install tests that supports specific architectures only. It can be useful in systems where is available an user-space emulator (e.g. FEX-EMU for x86_64 applications on aarch64) to run binary tests that cannot be compiled natively.',
+			'default' => false,
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
+
 		);
 
 	public static function read($name, &$overrides = null, $fallback_value = false)


### PR DESCRIPTION
This option allows to specify additional architecture support to being able to install tests that supports specific architecures only. It can be useful in systems where is available an user-space emulator (e.g. FEX-EMU for x86_64 applications on aarch64) to run binary tests that cannot be compiled natively.

The introduced environment variable is HOST_EXTRA_COMPATIBLE_ARCH.