### PR TITLE
Ignore psys domain for CPU power sensor

### DIFF
--- a/pts-core/objects/phodevi/sensors/cpu_power.php
+++ b/pts-core/objects/phodevi/sensors/cpu_power.php
@@ -115,6 +115,13 @@ class cpu_power extends phodevi_sensor
 				$rapl_base_path_1 = $rapl_base_path . $x;
 				if(is_readable($rapl_base_path_1))
 				{
+					$domain_name = pts_file_io::file_get_contents($rapl_base_path_1 . '/name');
+					if (strncmp($domain_name, "psys", 4) === 0)
+					{
+						// Ignore psys domain
+						continue;
+					}
+
 					$energy_uj = pts_file_io::file_get_contents($rapl_base_path_1 . '/energy_uj');
 					if(is_numeric($energy_uj))
 					{


### PR DESCRIPTION
psys domain is a system domain which aggregates all system power. This requires hardware support and configuration by OEMs. There can be multiple psys domains in servers. psys domains are present at the same level as package domains in the powercap/intel-rapl sysfs. This is not just CPU related power.

For CPU power sensor just use package level without adding energy values from psys domains. So, skip adding psys energy value to $total_energy.