### PR TITLE
Windows: Log Windows 10/11 version

### DIFF
--- a/pts-core/objects/phodevi/components/phodevi_system.php
+++ b/pts-core/objects/phodevi/components/phodevi_system.php
@@ -1364,15 +1364,14 @@ class phodevi_system extends phodevi_device_interface
 			// Windows 10 20H2 and newer store the version (20H2, etc.) in 'DisplayVersion' registry value
 			// Earlier (now out-of-support) versions used 'ReleaseId' in the same key
 			$windows_display_version = trim(shell_exec('powershell -NoProfile "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' DisplayVersion) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' DisplayVersion).DisplayVersion } Else { $null }"'));
-			$windows_build_number = phodevi::read_property('system', 'os-version');
 
 			$os_string = $windows_caption;
 
 			if ($windows_display_version !== null && $windows_display_version !== '') {
 				$os_string = $os_string . ' ' . $windows_display_version;
+			} else {
+				$os_string = $os_string . ' Build ' . phodevi::read_property('system', 'os-version');
 			}
-
-			$os_string = $os_string . ' Build ' . $windows_build_number;
 
 			$os = $info = $os_string;
 			if(strpos($os, 'Windows') === false)

--- a/pts-core/objects/phodevi/components/phodevi_system.php
+++ b/pts-core/objects/phodevi/components/phodevi_system.php
@@ -1360,7 +1360,21 @@ class phodevi_system extends phodevi_device_interface
 		}
 		else if(phodevi::is_windows())
 		{
-			$os = $info = phodevi_windows_parser::get_wmi_object('win32_operatingsystem', 'caption') . ' Build ' . phodevi::read_property('system', 'os-version');
+			$windows_caption = phodevi_windows_parser::get_wmi_object('win32_operatingsystem', 'caption');
+			// Windows 10 20H2 and newer store the version (20H2, etc.) in 'DisplayVersion' registry value
+			// Earlier (now out-of-support) versions used 'ReleaseId' in the same key
+			$windows_display_version = trim(shell_exec('powershell -NoProfile "If (Get-ItemProperty -ErrorAction SilentlyContinue -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' DisplayVersion) { (Get-ItemProperty -Path \'Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\' DisplayVersion).DisplayVersion } Else { $null }"'));
+			$windows_build_number = phodevi::read_property('system', 'os-version');
+
+			$os_string = $windows_caption;
+
+			if ($windows_display_version !== null && $windows_display_version !== '') {
+				$os_string = $os_string . ' ' . $windows_display_version;
+			}
+
+			$os_string = $os_string . ' Build ' . $windows_build_number;
+
+			$os = $info = $os_string;
 			if(strpos($os, 'Windows') === false)
 			{
 				$os = trim(exec('ver'));


### PR DESCRIPTION
Include the Windows 10/11 version (24H2, etc.) in the operating system string instead of the build number.

Current behaviour: `Microsoft Windows 11 Home Build 26100`
New behaviour: `Microsoft Windows 11 Home 24H2`

Recent Windows releases have introduced substantial scheduling changes that affect both [AMD](https://www.youtube.com/watch?v=izqEZmjTfuM) and Intel CPUs, so it's useful to see at a glance what version was used for benchmarking. The version can be inferred from the build number, but '24H2' is more meaningful to most people than 'Build 26100'. The build number and build revision (the latter of which can be significant for performance) are still reported in `sw_kernel()`.

I was thinking it would be nice to include the version in the result identifier (e.g. 'Windows 11 24H2' instead of 'Windows 11'), too, but I couldn't see where that value is set.