### PR TITLE
phodevi_cpu: add LoongArch processor detection support

### DIFF
--- a/pts-core/objects/phodevi/components/phodevi_cpu.php
+++ b/pts-core/objects/phodevi/components/phodevi_cpu.php
@@ -532,7 +532,7 @@ class phodevi_cpu extends phodevi_device_interface
 			$physical_cpu_ids = phodevi_linux_parser::read_cpuinfo('physical id');
 			$physical_cpu_count = count(array_unique($physical_cpu_ids));
 
-			$cpu_strings = phodevi_linux_parser::read_cpuinfo(array('model name', 'Processor', 'cpu', 'cpu model'));
+			$cpu_strings = phodevi_linux_parser::read_cpuinfo(array('model name', 'Processor', 'cpu', 'cpu model', 'Model Name'));
 
 			$cpu_strings_unique = array_unique($cpu_strings);
 


### PR DESCRIPTION
LoongArch processors uses the "Model Name:" field in /proc/cpuinfo to denote the processor model, a snippet below:

```
processor               : 31
package                 : 0
core                    : 31
global_id               : 31
CPU Family              : Loongson-64bit
Model Name              : Loongson-3C6000
CPU Revision            : 0x10
FPU Revision            : 0x00
CPU MHz                 : 2200.00
BogoMIPS                : 4400.00
TLB Entries             : 2112
Address Sizes           : 48 bits physical, 48 bits virtual
ISA                     : loongarch32r loongarch32s loongarch64
Features                : cpucfg lam ual fpu lsx lasx crc32 complex crypto lspw lvz lbt_x86 lbt_arm lbt_mips
Hardware Watchpoint     : yes, iwatch count: 8, dwatch count: 4
```

Add "Model Name" to the array of patterns to define `$cpu_strings` via `phodevi_linux_parser::read_cpuinfo()`.