### PR TITLE
Configured correct EOF characters by adding the .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+install-sh text eol=lf
+install_macos text eol=lf
+phoronix-test-suite text eol=lf


### PR DESCRIPTION
Configured correct EOF characters: if `phoronix-test-suite` was cloned using a Windows Git client but later the test suite run from MSYS2 or CygWin bash shell, there were errors in all fils which had to be run by bash (sh), i.e. those containing `#!/bin/sh`

Please note that if you switch the branch after the repository is cloned, Git would not change the EOF characters. Unless there is a .gitattributes file in the master branch, use --branch tag to clone a branch with the file.