### PR TITLE
pts-core: Parsing result format with ":#_RESULT_#"

### DIFF
--- a/pts-core/objects/pts_test_result_parser.php
+++ b/pts-core/objects/pts_test_result_parser.php
@@ -592,7 +592,7 @@ class pts_test_result_parser
 		$template_line = substr($template, 0, ($end_result_line_pos === false ? strlen($template) : $end_result_line_pos));
 		$template_line = substr($template_line, strrpos($template_line, "\n"));
 		pts_test_result_parser::debug_message('Template Line: ' . $template_line);
-		$template_r = explode(' ', pts_strings::trim_spaces(str_replace($space_out_chars, ' ', str_replace('=', ' = ', $template_line))));
+		$template_r = explode(' ', pts_strings::trim_spaces(str_replace($space_out_chars, ' ', str_replace('=', ' = ', (str_replace(':#', ' #',$template_line))))));
 		$template_r_pos = array_search($key_for_result, $template_r);
 
 		if($template_r_pos === false)


### PR DESCRIPTION
Some benchmark output reports are in the format:
xyz score:XYZ

Here there is no space between ':' and actual result.

To parse such format create a template something like this: <OutputTemplate>xxx:#_RESULT_#</OutputTemplate>

This type of the format can't be parsed correctly.

The current implementation expects a "space" after column. For example:
In test-profiles/system/selenium-1.0.18/results-definition.xml <ResultsParser>
  <OutputTemplate>WEBXPRT SCORE RESULT: #_RESULT_#</OutputTemplate>

To be able to parse when there is no space between ":" and "#" add a a space character in the template line.