### PR TITLE
Feat: Higher cost calculation precision - make precision configurable

### DIFF
--- a/pts-core/modules/perf_per_dollar.php
+++ b/pts-core/modules/perf_per_dollar.php
@@ -126,10 +126,10 @@ class perf_per_dollar extends pts_module_interface
 			{
 				// Cost-perf-per-hour calculation, e.g. cloud costs...
 				// self::$TEST_RUN_TIME_ELAPSED is seconds run.....
-				$cost_to_run_test = round((self::$COST_PERF_PER_HOUR / 60 / 60) * self::$TEST_RUN_TIME_ELAPSED, 2);
+				$cost_to_run_test = round((self::$COST_PERF_PER_HOUR / 60 / 60) * self::$TEST_RUN_TIME_ELAPSED, 11);
 
-				if($cost_to_run_test < 0.01)
-					return;
+				//if($cost_to_run_test < 0.01)
+				//	return;
 
 				$cost_perf_value = $cost_to_run_test;
 				$footnote = '$' . self::$COST_PERF_PER_HOUR . ' reported cost per hour, test consumed ' . pts_strings::format_time(self::$TEST_RUN_TIME_ELAPSED) . ': cost approximately ' . $cost_perf_value . ' ' . strtolower(self::$COST_PERF_PER_UNIT) . '.';
@@ -187,10 +187,11 @@ class perf_per_dollar extends pts_module_interface
 			if(self::$COST_PERF_PER_HOUR > 0)
 			{
 				// Cost-perf-per-hour calculation, e.g. cloud costs...
-				$cost_to_run_test = round((self::$COST_PERF_PER_HOUR / 60 / 60) * $total_elapsed_test_time, 2);
+				$cost_to_run_test = round((self::$COST_PERF_PER_HOUR / 60 / 60) * $total_elapsed_test_time, 11);
 
-				if($cost_to_run_test < 0.01)
-					return;
+				//if($cost_to_run_test < 0.01)
+				//	return;
+
 				$footnote = '$' . self::$COST_PERF_PER_HOUR . ' reported cost per hour, running tests consumed ' . pts_strings::format_time($total_elapsed_test_time) . ': cost approximately ' . $cost_to_run_test . ' ' . strtolower(self::$COST_PERF_PER_UNIT) . '.';
 				$test_profile = new pts_test_profile();
 				$test_result = new pts_test_result($test_profile);

--- a/pts-core/objects/pts_math.php
+++ b/pts-core/objects/pts_math.php
@@ -175,7 +175,7 @@ class pts_math
 			return strlen(substr(strrchr($number, '.'), 1));
 		}
 	}
-	public static function set_precision($number, $precision = 2)
+	public static function set_precision($number, $precision = 11)
 	{
 		// This is better than using round() with precision because of the $precision is > than the current value, 0s will not be appended
 		return is_numeric($number) ? number_format($number, $precision, '.', '') : $number;


### PR DESCRIPTION
When running Phoronix on cloud provider VMs the current price calculation precision of 2 is often not enough.
Especially if the calculations are intended to use hourly prices, a precision of 2 will lead to wrong calculations through falling back to a value of `0.01`

StackIT for example uses a precision of 11 for price tags. So servers are eventually priced with low values under 0.003. Using 0.01 as lowest possible value can lead to significant calculation errors.
https://www.stackit.de/wp-content/uploads/2024/08/240814_STACKIT_Pricelist_v1.0.21_A4.pdf?x49748

I suggest to change the default precision or make the precision configurable.