### PR TITLE
Use sdr cache for IPMI readings

### DIFF
--- a/pts-core/objects/phodevi/parsers/phodevi_linux_parser.php
+++ b/pts-core/objects/phodevi/parsers/phodevi_linux_parser.php
@@ -26,7 +26,10 @@ class phodevi_linux_parser
 	public static function read_ipmitool_sensor($sensors, $default_value = false)
 	{
 		$value = $default_value;
-		$ipmitool = shell_exec('ipmitool sdr list 2>&1');
+		if(!file_exists('/tmp/.pts_sdr_cache')) {
+			$ipmitool = shell_exec('ipmitool sdr dump /tmp/.pts_sdr_cache 2>&1');
+		}
+		$ipmitool = shell_exec('ipmitool -S /tmp/.pts_sdr_cache sdr list 2>&1');
 
 		foreach(pts_arrays::to_array($sensors) as $sensor)
 		{


### PR DESCRIPTION
Hi Michael,

This is a quick and dirty patch so `ipmitool sdr list` uses sdr cache. This shortens a lot ipmitool running time, and may prevent some benchmarks getting stuck due to (I suppose - didn’t have time to dig deeper) too long running time to get output between two calls of `read_ipmitool_sensor` function.