### PR TITLE
cloudsuite v4 1.3.0 fix docker images

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update
+RUN apt-update
 RUN apt-get install -y unzip php-cli apt-utils mesa-utils php-xml git-core apt-file sudo vim 
 RUN apt-get install -y podman
-RUN apt-get install -y shadow-utils fuse-overlayfs; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN apt-get install -y shadow-utils fuse-overlayfs
 
 RUN useradd podman; \
 echo podman:10000:5000 > /etc/subuid; \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update
+RUN apt-get install -y unzip php-cli apt-utils mesa-utils php-xml git-core apt-file sudo vim
+RUN apt-get install -y podman
+
+# Copy the local phoronix-test-suite directory to the container
+COPY . /phoronix-test-suite/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,21 @@
 FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update
-RUN apt-get install -y unzip php-cli apt-utils mesa-utils php-xml git-core apt-file sudo vim
+RUN apt-get install -y unzip php-cli apt-utils mesa-utils php-xml git-core apt-file sudo vim 
 RUN apt-get install -y podman
+RUN apt-get install -y shadow-utils fuse-overlayfs; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
-# Copy the local phoronix-test-suite directory to the container
+RUN useradd podman; \
+echo podman:10000:5000 > /etc/subuid; \
+echo podman:10000:5000 > /etc/subgid;
+
+VOLUME /var/lib/containers
+VOLUME /home/podman/.local/share/containers
+
+
+RUN chown podman:podman -R /home/podman
+
+# chmod containers.conf and adjust storage.conf to enable Fuse storage.
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
+ENV _CONTAINERS_USERNS_CONFIGURED=""
 COPY . /phoronix-test-suite/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-update
+RUN apt-get update
 RUN apt-get install -y unzip php-cli apt-utils mesa-utils php-xml git-core apt-file sudo vim 
 RUN apt-get install -y podman
-RUN apt-get install -y shadow-utils fuse-overlayfs
+
 
 RUN useradd podman; \
 echo podman:10000:5000 > /etc/subuid; \
@@ -15,7 +15,4 @@ VOLUME /home/podman/.local/share/containers
 
 RUN chown podman:podman -R /home/podman
 
-# chmod containers.conf and adjust storage.conf to enable Fuse storage.
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
-ENV _CONTAINERS_USERNS_CONFIGURED=""
 COPY . /phoronix-test-suite/

--- a/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/install.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+if which podman>/dev/null 2>&1 ;
+then
+	echo 0 > ~/install-exit-status
+else
+	echo "ERROR: podman is not found on the system! This test profile needs a working docker installation in the PATH."
+	echo 2 > ~/install-exit-status
+	exit
+fi
+echo step1
+
+echo $? > ~/install-exit-status
+echo "#!/bin/bash
+export HOME=\$DEBUG_REAL_HOME 
+HOST_MASTER=$(hostname -I | awk '{print $1}')
+
+echo pulling cloudsuite/data-analytics
+podman pull docker.io/cloudsuite/data-analytics
+
+echo pulling cloudsuite/wikimedia-pages-dataset
+podman pull docker.io/cloudsuite/wikimedia-pages-dataset
+
+echo running cloudsuite/wikimedia-pages-dataset
+podman run --privileged --name wikimedia-dataset docker.io/cloudsuite/wikimedia-pages-dataset
+
+# Start master and slaves
+SLAVE_COUNT=\$1
+
+echo running master
+podman run -d --privileged --net host --volumes-from wikimedia-dataset --name master docker.io/cloudsuite/data-analytics --master
+
+for (( SLAVE_I=1; SLAVE_I<=\$SLAVE_COUNT; SLAVE_I++ ))
+do
+   echo running slave\$SLAVE_I
+   podman run --privileged -d --net host --name slave\$SLAVE_I docker.io/cloudsuite/data-analytics --slave --master-ip=\$HOST_MASTER
+done
+
+# Run data analytics benchmark
+podman exec master benchmark > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status
+
+# Stop them
+podman stop master
+for (( SLAVE_I=1; SLAVE_I<=\$SLAVE_COUNT; SLAVE_I++ ))
+do 
+   podman stop slave\$SLAVE_I
+done
+
+sleep 2
+podman container rm master
+
+for (( SLAVE_I=1; SLAVE_I<=\$SLAVE_COUNT; SLAVE_I++ ))
+do 
+   podman container rm slave\$SLAVE_I
+done
+
+podman rm wikimedia-dataset
+" > cloudsuite-da
+chmod +x cloudsuite-da

--- a/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Benchmark time: #_RESULT_#</OutputTemplate>
+    <StripFromResult>ms</StripFromResult>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/test-definition.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>CloudSuite Data Analytics</Title>
+    <AppVersion>4.0</AppVersion>
+    <Description>CloudSuite Data Analytics is a Docker-based benchmark and runs a Naive Bayes classifier on a Wikimedia dataset with Hadoop and Mahout.</Description>
+    <ResultScale>ms</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>1</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.3.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>700</EnvironmentSize>
+    <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/master/docs/benchmarks/data-analytics.md</ProjectURL>
+    <RepositoryURL>https://github.com/parsa-epfl/cloudsuite/</RepositoryURL>
+    <InternalTags>Cloud, Docker</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>docker</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Hadoop Slaves</DisplayName>
+      <Identifier>slaves</Identifier>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+        </Entry>
+        <Entry>
+          <Name>4</Name>
+          <Value>4</Value>
+        </Entry>
+        <Entry>
+          <Name>8</Name>
+          <Value>8</Value>
+        </Entry>
+        <Entry>
+          <Name>32</Name>
+          <Value>32</Value>
+        </Entry>
+        <Entry>
+          <Name>64</Name>
+          <Value>64</Value>
+        </Entry>
+        <Entry>
+          <Name>128</Name>
+          <Value>128</Value>
+        </Entry>
+        <Entry>
+          <Name>256</Name>
+          <Value>256</Value>
+        </Entry>
+        <Entry>
+          <Name>512</Name>
+          <Value>512</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-da-1.3.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>CloudSuite Data Analytics</Title>
     <AppVersion>4.0</AppVersion>
-    <Description>CloudSuite Data Analytics is a Docker-based benchmark and runs a Naive Bayes classifier on a Wikimedia dataset with Hadoop and Mahout.</Description>
+    <Description>CloudSuite Data Analytics is a Podman-based benchmark and runs a Naive Bayes classifier on a Wikimedia dataset with Hadoop and Mahout.</Description>
     <ResultScale>ms</ResultScale>
     <Proportion>LIB</Proportion>
     <TimesToRun>1</TimesToRun>
@@ -20,9 +20,9 @@
     <EnvironmentSize>700</EnvironmentSize>
     <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/master/docs/benchmarks/data-analytics.md</ProjectURL>
     <RepositoryURL>https://github.com/parsa-epfl/cloudsuite/</RepositoryURL>
-    <InternalTags>Cloud, Docker</InternalTags>
-    <Maintainer>Michael Larabel</Maintainer>
-    <SystemDependencies>docker</SystemDependencies>
+    <InternalTags>Cloud, Podman</InternalTags>
+    <Maintainer>Ahmed Eleliemy</Maintainer>
+    <SystemDependencies>podman</SystemDependencies>
   </TestProfile>
   <TestSettings>
     <Option>

--- a/ob-cache/test-profiles/pts/cloudsuite-ga-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ga-1.2.0/install.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+if which podman>/dev/null 2>&1 ;
+then
+	echo 0 > ~/install-exit-status
+else
+	echo "ERROR: podman is not found on the system! This test profile needs a working docker installation in the PATH."
+	echo 2 > ~/install-exit-status
+	exit
+fi
+
+podman pull docker.io/cloudsuite/graph-analytics
+podman pull docker.io/cloudsuite/twitter-dataset-graph
+echo $? > ~/install-exit-status
+
+
+echo "#!/bin/bash
+export HOME=\$DEBUG_REAL_HOME 
+
+# Start
+podman run --privileged --name data-ga docker.io/cloudsuite/twitter-dataset-graph
+
+# Run benchmark
+podman run --privileged --net host --rm --volumes-from data-ga -e WORKLOAD_NAME=pr docker.io/cloudsuite/graph-analytics --driver-memory 16g --executor-memory 16g \$@ > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status
+
+# Stop them
+podman stop data-ga
+podman container rm data-ga
+
+" > cloudsuite-ga
+chmod +x cloudsuite-ga

--- a/ob-cache/test-profiles/pts/cloudsuite-ga-1.2.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ga-1.2.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Running time = #_RESULT_#</OutputTemplate>
+    <StripFromResult>ms</StripFromResult>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ga-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ga-1.2.0/test-definition.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>CloudSuite Graph Analytics</Title>
+    <Description>CloudSuite Graph Analytics uses Apache GraphX + Spark to perform graph analytics (PageRank) on sample Twitter data.</Description>
+    <ResultScale>ms</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>700</EnvironmentSize>
+    <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/master/docs/benchmarks/graph-analytics.md</ProjectURL>
+    <InternalTags>Cloud, podman</InternalTags>
+    <Maintainer>Ahmed Eleliemy</Maintainer>
+    <SystemDependencies>podman</SystemDependencies>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/install.sh
@@ -13,11 +13,11 @@ echo $? > ~/install-exit-status
 echo "#!/bin/bash
 export HOME=\$DEBUG_REAL_HOME
 # Start
-podman run --privileged --name movielens-data docker.io/cloudsuite/movielens-dataset
+podman run --privileged --name movielens-data docker.io/cloudsuite3/movielens-dataset
 # Run in-memory analytics benchmark
 MEMORY_LIMIT=\`echo \"scale=0;\$SYS_MEMORY / 1024 * 0.91\" |bc -l | cut -d'.' -f1\`
 echo \"Memory Limit is \${MEMORY_LIMIT}g\"
-podman run --privileged --rm --volumes-from movielens-data docker.io/cloudsuite/in-memory-analytics \"\$1\" /data/myratings.csv --driver-memory \${MEMORY_LIMIT}g --executor-memory \${MEMORY_LIMIT}g > \$LOG_FILE 2>&1
+podman run --privileged --rm --volumes-from movielens-data docker.io/cloudsuite3/in-memory-analytics \"\$1\" /data/myratings.csv --driver-memory \${MEMORY_LIMIT}g --executor-memory \${MEMORY_LIMIT}g > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status
 # Stop them
 podman stop movielens-data

--- a/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/install.sh
@@ -7,17 +7,17 @@ else
 	echo 2 > ~/install-exit-status
 	exit
 fi
-podman pull docker.io/cloudsuite3/in-memory-analytics
-podman pull docker.io/cloudsuite3/movielens-dataset
+podman pull docker.io/cloudsuite/in-memory-analytics
+podman pull docker.io/cloudsuite/movielens-dataset
 echo $? > ~/install-exit-status
 echo "#!/bin/bash
 export HOME=\$DEBUG_REAL_HOME
 # Start
-podman run --privileged --name movielens-data docker.io/cloudsuite3/movielens-dataset
+podman run --privileged --name movielens-data docker.io/cloudsuite/movielens-dataset
 # Run in-memory analytics benchmark
 MEMORY_LIMIT=\`echo \"scale=0;\$SYS_MEMORY / 1024 * 0.91\" |bc -l | cut -d'.' -f1\`
 echo \"Memory Limit is \${MEMORY_LIMIT}g\"
-podman run --privileged --rm --volumes-from movielens-data docker.io/cloudsuite3/in-memory-analytics \"\$1\" /data/myratings.csv --driver-memory \${MEMORY_LIMIT}g --executor-memory \${MEMORY_LIMIT}g > \$LOG_FILE 2>&1
+podman run --privileged --rm --volumes-from movielens-data docker.io/cloudsuite/in-memory-analytics \"\$1\" /data/myratings.csv --driver-memory \${MEMORY_LIMIT}g --executor-memory \${MEMORY_LIMIT}g > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status
 # Stop them
 podman stop movielens-data

--- a/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/install.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+if which podman>/dev/null 2>&1 ;
+then
+	echo 0 > ~/install-exit-status
+else
+	echo "ERROR: Podman is not found on the system! This test profile needs a working podman installation in the PATH."
+	echo 2 > ~/install-exit-status
+	exit
+fi
+podman pull docker.io/cloudsuite3/in-memory-analytics
+podman pull docker.io/cloudsuite3/movielens-dataset
+echo $? > ~/install-exit-status
+echo "#!/bin/bash
+export HOME=\$DEBUG_REAL_HOME
+# Start
+podman run --privileged --name movielens-data docker.io/cloudsuite/movielens-dataset
+# Run in-memory analytics benchmark
+MEMORY_LIMIT=\`echo \"scale=0;\$SYS_MEMORY / 1024 * 0.91\" |bc -l | cut -d'.' -f1\`
+echo \"Memory Limit is \${MEMORY_LIMIT}g\"
+podman run --privileged --rm --volumes-from movielens-data docker.io/cloudsuite/in-memory-analytics \"\$1\" /data/myratings.csv --driver-memory \${MEMORY_LIMIT}g --executor-memory \${MEMORY_LIMIT}g > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status
+# Stop them
+podman stop movielens-data
+podman container rm movielens-data
+" > cloudsuite-ma
+chmod +x cloudsuite-ma

--- a/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Benchmark execution time: #_RESULT_#</OutputTemplate>
+    <StripFromResult>ms</StripFromResult>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/test-definition.xml
@@ -10,7 +10,7 @@
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <SupportedPlatforms>Linux</SupportedPlatforms>
     <SoftwareType>Utility</SoftwareType>
     <TestType>System</TestType>

--- a/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ma-1.2.0/test-definition.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>CloudSuite In-Memory Analytics</Title>
+    <AppVersion>4.0</AppVersion>
+    <Description>CloudSuite In-Memory Analytics uses Apache Spark and runs a collaborative filtering algorithm in-memory on a dataset of user-movie ratings from Movielens.</Description>
+    <ResultScale>ms</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>700</EnvironmentSize>
+    <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/master/docs/benchmarks/in-memory-analytics.md</ProjectURL>
+    <RepositoryURL>https://github.com/parsa-epfl/cloudsuite/</RepositoryURL>
+    <InternalTags>Cloud, Docker</InternalTags>
+    <Maintainer>Ahmed Eleliemy</Maintainer>
+    <SystemDependencies>docker, bc</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Training Set Size</DisplayName>
+      <Identifier>size</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Small</Name>
+          <Value>/data/ml-latest-small</Value>
+        </Entry>
+        <Entry>
+          <Name>Large</Name>
+          <Value>/data/ml-latest</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/install.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+if which podman>/dev/null 2>&1 ;
+then
+	echo 0 > ~/install-exit-status
+else
+	echo "ERROR: Podman is not found on the system! This test profile needs a working docker installation in the PATH."
+	echo 2 > ~/install-exit-status
+	exit
+fi
+
+podman pull cloudsuite/media-streaming:dataset
+podman pull cloudsuite/media-streaming:server
+docker pull cloudsuite/media-streaming:client
+echo $? > ~/install-exit-status
+
+echo "#!/bin/bash
+export HOME=\$DEBUG_REAL_HOME 
+
+# Start
+podman network create streaming_network
+
+podman run --name streaming_dataset cloudsuite/media-streaming:dataset
+podman run -d --name streaming_server --volumes-from streaming_dataset --net streaming_network cloudsuite3/media-streaming:server
+
+# Run media streaming benchmark
+podman run -t --name=streaming_client -v /path/to/output:/output --volumes-from streaming_dataset --net streaming_network cloudsuite3/media-streaming:client streaming_server \$@ > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status
+
+# Stop them
+podman stop streaming_dataset
+podman stop streaming_server
+podman stop streaming_client
+podman container rm streaming_dataset
+podman container rm streaming_server
+podman container rm streaming_client" > cloudsuite-ms
+chmod +x cloudsuite-ms

--- a/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Reply rate: #_RESULT_#</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/test-definition.xml
@@ -20,7 +20,7 @@
     <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/master/docs/benchmarks/media-streaming.md</ProjectURL>
     <RepositoryURL>https://github.com/parsa-epfl/cloudsuite/</RepositoryURL>
     <InternalTags>Cloud, podman</InternalTags>
-    <Maintainer>Michael Larabel</Maintainer>
+    <Maintainer>Ahmed Eleliemy</Maintainer>
     <SystemDependencies>podman</SystemDependencies>
   </TestProfile>
 </PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ms-1.2.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>CloudSuite Media Streaming</Title>
+    <Description>CloudSuite Media Streaming uses the Nginx web server for hosted videos of varying lengths/qualities.</Description>
+    <ResultScale>Reply Rate</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>1</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>700</EnvironmentSize>
+    <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/master/docs/benchmarks/media-streaming.md</ProjectURL>
+    <RepositoryURL>https://github.com/parsa-epfl/cloudsuite/</RepositoryURL>
+    <InternalTags>Cloud, podman</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>podman</SystemDependencies>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/install.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+if which podman>/dev/null 2>&1 ;
+then
+	echo 0 > ~/install-exit-status
+else
+	echo "ERROR: Podman is not found on the system! This test profile needs a working podman installation in the PATH."
+	echo 2 > ~/install-exit-status
+	exit
+fi
+podman pull docker.io/cloudsuite/web-serving:db_server
+podman pull docker.io/cloudsuite/web-serving:memcached_server
+podman pull docker.io/cloudsuite/web-serving:web_server
+podman pull docker.io/cloudsuite/web-serving:faban_client
+echo $? > ~/install-exit-status
+podman network create search_network
+echo "#!/bin/bash
+# Run data analytics benchmark
+podman run --net=host --name=faban_client docker.io/cloudsuite/web-serving:faban_client 127.0.0.1 \$@ --steady=60 > pts-run.log 2>&1
+echo \$? > ~/test-exit-status
+cat pts-run.log | grep metric | tr '<' ' ' | tr '>' ' ' > \$LOG_FILE
+podman stop faban_client
+podman container rm faban_client" > cloudsuite-ws
+chmod +x cloudsuite-ws

--- a/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/post.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/post.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+docker stop database_server
+docker stop memcache_server
+docker stop web_server
+docker stop faban_client
+
+docker container rm database_server
+docker container rm memcache_server
+docker container rm web_server
+docker container rm faban_client

--- a/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/pre.sh
+++ b/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/pre.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Start master and slaves
+podman run -dt --net=host --name=database_server docker.io/cloudsuite/web-serving:db_server
+# database_server needs time to download payload from Internet...
+while ! podman logs database_server | grep -q "Starting MariaDB database server";
+do
+    sleep 5
+    echo "waiting on db server to start..."
+done
+podman run -dt --net=host --name=memcache_server docker.io/cloudsuite/web-serving:memcached_server
+IP_ADDR=`hostname -I | cut -d" " -f1`
+podman run -dt --net=host --name=web_server docker.io/cloudsuite/web-serving:web_server /etc/bootstrap.sh http $IP_ADDR $IP_ADDR $IP_ADDR 800

--- a/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>         metric unit="ops/sec" #_RESULT_# /metric</OutputTemplate>
+    <LineHint>ops/sec</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/cloudsuite-ws-1.2.0/test-definition.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>CloudSuite Web Serving</Title>
+    <Description>CloudSuite Web Serving is a Docker-based web server benchmark making use of a web server with Memcached and a MySQL database server.</Description>
+    <ResultScale>ops/sec</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>1</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>700</EnvironmentSize>
+    <ProjectURL>https://github.com/parsa-epfl/cloudsuite/blob/CSv3/docs/benchmarks/web-serving.md</ProjectURL>
+    <RepositoryURL>https://github.com/parsa-epfl/cloudsuite/</RepositoryURL>
+    <InternalTags>Cloud, Podman</InternalTags>
+    <Maintainer>Ahmed Eleliemy</Maintainer>
+    <SystemDependencies>podman</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Load Scale</DisplayName>
+      <Identifier>load-scale</Identifier>
+      <Menu>
+        <Entry>
+          <Name>100</Name>
+          <Value>100 --ramp-up=120</Value>
+        </Entry>
+        <Entry>
+          <Name>400</Name>
+          <Value>400 --ramp-up=440</Value>
+        </Entry>
+        <Entry>
+          <Name>500</Name>
+          <Value>500 --ramp-up=550</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
This PR 
1- fixes the issue of the none-existing docker images of cloudsuite v4 benchmark (data analytics, graphic analytics, web serving)
2- it adds also the memory streaming benchmark
3- enable use of rootless podman rather than docker 