### PR TITLE
ClickHouse: Added graceful server shutdown and throughput benchmark

### DIFF
--- a/ob-cache/test-profiles/pts/clickhouse-1.3.0/install.sh
+++ b/ob-cache/test-profiles/pts/clickhouse-1.3.0/install.sh
@@ -10,8 +10,14 @@ gzip -d -k hits.tsv.gz
 cp ClickBench-d9a1281ca7d2dd6c5144bd801a5ce493c0fe6fa0/clickhouse/queries.sql queries.sql
 mkdir config.d
 
-CLICKHOUSE_CLIENT=clickhouse-common-static-25.8.7.3/usr/bin/clickhouse
+CLICKHOUSE_EXECUTABLE=clickhouse-common-static-25.8.7.3/usr/bin/clickhouse
 echo "#!/bin/bash
+# Benchmark harness expects 0, all exit codes must be 0 to pass
+# Dumping and replacing non-zero code(s) to fail the run
+update_test_exit_status() {
+	[ \$1 -ne 0 ] && echo \$1 > ~/test-exit-status;
+}
+
 rm -rf d*
 rm -rf f*
 rm -rf m*
@@ -22,29 +28,64 @@ rm -rf tmp
 rm -rf u*
 
 TRIES=3
-./$CLICKHOUSE_CLIENT server 2>/dev/null &
+# Launch the server in its own process group so it doesn’t forward SIGTERM signals when shutting down
+setsid ./$CLICKHOUSE_EXECUTABLE server \$CLICKHOUSE_SERVER_ARGS 2>/dev/null &
 SERVER_PID=\$!
+#disown \$SERVER_PID;
 sleep 5
-./$CLICKHOUSE_CLIENT client < ClickBench-d9a1281ca7d2dd6c5144bd801a5ce493c0fe6fa0/clickhouse/create-tuned.sql
-./$CLICKHOUSE_CLIENT client --time --query \"INSERT INTO hits FORMAT TSV\" < hits.tsv
-echo \$? > ~/test-exit-status
-cat queries.sql | while read query; do
-    sync
-    echo \"QUERY: \$query\" >> \$LOG_FILE
-    for i in \$(seq 1 \$TRIES); do
-        echo -n \"Clickhouse Query Time \$i: \" >> \$LOG_FILE
-        ./$CLICKHOUSE_CLIENT client --time --format=Null --max_memory_usage=100G --max_threads=\$NUM_CPU_CORES --query=\"\$query\" --progress 0 >> \$LOG_FILE 2>&1
-        retval=\$?
-        if [ \$retval -ne 0 ]; then
-	    echo \$retval > ~/test-exit-status
-	    kill -9 \$SERVER_PID
-	    sleep 3
-	    exit
-	fi
-    done
+echo 0 > ~/test-exit-status
+./$CLICKHOUSE_EXECUTABLE client < ClickBench-d9a1281ca7d2dd6c5144bd801a5ce493c0fe6fa0/clickhouse/create-tuned.sql
+update_test_exit_status \$?
+./$CLICKHOUSE_EXECUTABLE client --time --query \"INSERT INTO hits FORMAT TSV\" < hits.tsv
+update_test_exit_status \$?
+
+# Latency Benchmarks, First iteration for every query is cold
+while IFS= read -r query; do
+	# sync dirty pages to disk then drop caches
+	sync
+	echo 3 | sudo -n tee /proc/sys/vm/drop_caches >/dev/null 2>&1 
+	DIRTY_CACHE=\$?
+	echo \"QUERY: \$query\" >> \$LOG_FILE
+	for i in \$(seq 1 \$TRIES); do
+		# if caches have not dropped succesfully we can't validate the cold iteration
+		[[ \$DIRTY_CACHE -eq 0 || \$i -gt 1 ]] && echo -n \"Clickhouse Query Time \$i: \" >> \$LOG_FILE || echo -n \"Cold Query Time is invalid (can't drop cache, sudo problem?): \" >> \$LOG_FILE
+		./$CLICKHOUSE_EXECUTABLE client --time --format=Null --max_memory_usage=100G --query=\"\$query\" --progress 0 >> \$LOG_FILE 2>&1
+		retval=\$?; if [ \$retval -ne 0 ]; then update_test_exit_status \$retval; break; fi
+	done
+done < queries.sql
+
+# Throughput Benchmark on warm data
+sync
+echo 3 | sudo -n tee /proc/sys/vm/drop_caches >/dev/null 2>&1 
+for i in \$(seq 0 \$TRIES); do
+	# Uses system ns timer, includes client(s) start-up and timer call overheads, better real-world scenario evaluation
+	start_time=\$(date +%s%N)
+	# Limiting  external parallelism by NUM_CPU_CORES processes, let OS and clickhouse server handle this
+	while IFS= read -r query; do
+		# Spinning on while if there is not enough CPUs provided, sleep command resolution is inconsistent
+		while [ \$(jobs -r | wc -l) -ge \$NUM_CPU_CORES ]; do :; done
+		(
+			./$CLICKHOUSE_EXECUTABLE client --format=Null --max_memory_usage=100G --query=\"\$query\" --progress 0 
+			# if one of queries fails just fail the full benchmark, error code does not matter
+			if [ \$? -ne 0 ]; then echo 1 > ~/test-exit-status; fi 
+		) &
+	done < queries.sql
+	for pid in \$(jobs -p); do [ \$pid -eq \$SERVER_PID ] && continue; wait \$pid; done
+	stop_time=\$(date +%s%N)
+
+	# Total execution time in nanoseconds
+	nanoseconds=\$(( \$stop_time - \$start_time ))
+	# Average time per query in seconds
+	seconds=\$(echo \$nanoseconds | awk -v nq=\$(grep -c \"\" queries.sql) '{printf \"%1.7f\n\", ((\$1/1000000000)/nq) }')
+	# skipping the cold iteration
+	[ \$i -ge 1 ] && echo \"Clickhouse Throughput Time: \$seconds \" >> \$LOG_FILE
 done
-kill -9 \$SERVER_PID
-sleep 2
+
+# Shutting the server down
+./$CLICKHOUSE_EXECUTABLE client --query='SYSTEM SHUTDOWN'
+sleep 5
+for pid in \$(jobs -p); do if [ \$pid -eq \$SERVER_PID ]; then kill -9 \$SERVER_PID; sleep 2; fi; done
+
 rm -rf d*
 rm -rf f*
 rm -rf m*

--- a/ob-cache/test-profiles/pts/clickhouse-1.3.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/clickhouse-1.3.0/results-definition.xml
@@ -6,20 +6,27 @@
     <LineHint>Clickhouse Query Time 1:</LineHint>
     <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
     <DivideResultDivisor>60</DivideResultDivisor>
-    <ArgumentsDescription>100M Rows Hits Dataset, First Run / Cold Cache</ArgumentsDescription>
+    <ArgumentsDescription>100M Rows Hits Dataset, Latency, First Run / Cold Cache</ArgumentsDescription>
   </ResultsParser>
   <ResultsParser>
     <OutputTemplate>Clickhouse Query Time 2: #_RESULT_#</OutputTemplate>
     <LineHint>Clickhouse Query Time 2:</LineHint>
     <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
     <DivideResultDivisor>60</DivideResultDivisor>
-    <ArgumentsDescription>100M Rows Hits Dataset, Second Run</ArgumentsDescription>
+    <ArgumentsDescription>100M Rows Hits Dataset, Latency, Second Run</ArgumentsDescription>
   </ResultsParser>
   <ResultsParser>
     <OutputTemplate>Clickhouse Query Time 3: #_RESULT_#</OutputTemplate>
     <LineHint>Clickhouse Query Time 3:</LineHint>
     <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
     <DivideResultDivisor>60</DivideResultDivisor>
-    <ArgumentsDescription>100M Rows Hits Dataset, Third Run</ArgumentsDescription>
+    <ArgumentsDescription>100M Rows Hits Dataset, Latency, Third Run</ArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Clickhouse Throughput Time: #_RESULT_#</OutputTemplate>
+    <LineHint>Clickhouse Throughput Time:</LineHint>
+    <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
+    <DivideResultDivisor>60</DivideResultDivisor>
+    <ArgumentsDescription>100M Rows Hits Dataset, Throughput</ArgumentsDescription>
   </ResultsParser>
 </PhoronixTestSuite>


### PR DESCRIPTION
1. Added graceful shutdown for the server
2. Server parallelism changed to default (auto), letting clickhouse to use optimized values for an underlying hardware https://clickhouse.com/docs/operations/settings/settings#max_threads
    * Different thread count is not default but can be controlled in experiments by custom configuration file passed via optional $CLICKHOUSE_SERVER_ARGS variable.

3. "Cold Cache" run was changed from simple sync to full RAM cache flush and it reports not-matching diagnostics in case there is not enough user permissions to clear the RAM cache.
   * But anyway there might be some cached data inside the server memory.
4. Current benchmark has been renamed to Latency.
    * Every query executed sequentially and uses server parallelism.
5. Added Throughput  benchmark:
    * All queries are executed concurrently, external parallelism is limited by NUM_CPU_CORES
    * Server parallelism can be utilized more efficiently.
    * $TRIES (3) has changed to $TRIES+1 (4), first pass is the warm-up pass.
    * The benchmark reports $TRIES warm times,  PTS harness reports geomean "Queries per minute" value for these runs
