### PR TITLE
oneDNN: adding AI data types, updated workloads and NUMA support

### DIFF
--- a/ob-cache/test-profiles/pts/onednn-3.8.0/downloads.xml
+++ b/ob-cache/test-profiles/pts/onednn-3.8.0/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/uxlfoundation/oneDNN/archive/refs/tags/v3.8.1.tar.gz</URL>
-      <MD5>d4e445d00725f9aec490f10b3dddeda9</MD5>
-      <SHA256>4b0638061a789a1efbefdcd2e85eb257c7b432b3b6a71ba8909e19d75f50b163</SHA256>
-      <FileName>oneDNN-3.8.1.tar.gz</FileName>
-      <FileSize>12938751</FileSize>
+      <URL>https://github.com/uxlfoundation/oneDNN/archive/refs/tags/v3.11.1.tar.gz</URL>
+      <MD5>8ecbd32b9556feac8e8e35bc0b8b1c27</MD5>
+      <SHA256>0ed141ee3ecf2856aef4966154a19b408faac50234581aeed4bd6e9dad09de68</SHA256>
+      <FileName>oneDNN-3.11.1.tar.gz</FileName>
+      <FileSize>13772368</FileSize>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/onednn-3.8.0/install.sh
+++ b/ob-cache/test-profiles/pts/onednn-3.8.0/install.sh
@@ -4,12 +4,12 @@ cd oneDNN-3.11.1
 mkdir build 
 cd build 
 CFLAGS="-O3 -march=native $CFLAGS" CXXFLAGS="-O3 -march=native $CXXFLAGS" cmake -DCMAKE_BUILD_TYPE=Release -DDNNL_GPU_RUNTIME=OCL MKLDNN_ARCH_OPT_FLAGS="-O3 -march=native $CFLAGS" $CMAKE_OPTIONS ..
-make -j $NUM_CPU_PHYSICAL_CORES
+make -j $NUM_CPU_CORES
 EXIT_STATUS=$?
 if [ $EXIT_STATUS -ne 0 ]; then
 	# For architectures not supporting -march=native compiler option...
 	CFLAGS="-O3 $CFLAGS" CXXFLAGS="-O3 $CXXFLAGS" cmake -DCMAKE_BUILD_TYPE=Release -DDNNL_GPU_RUNTIME=OCL MKLDNN_ARCH_OPT_FLAGS="-O3 $CFLAGS" $CMAKE_OPTIONS ..
-	make -j $NUM_CPU_PHYSICAL_CORES
+	make -j $NUM_CPU_CORES
 	EXIT_STATUS=$?
 fi
 echo $EXIT_STATUS > ~/install-exit-status

--- a/ob-cache/test-profiles/pts/onednn-3.8.0/install.sh
+++ b/ob-cache/test-profiles/pts/onednn-3.8.0/install.sh
@@ -1,24 +1,83 @@
 #!/bin/bash
-tar -xf oneDNN-3.8.1.tar.gz
-cd oneDNN-3.8.1
+tar -xf oneDNN-3.11.1.tar.gz
+cd oneDNN-3.11.1
 mkdir build 
 cd build 
 CFLAGS="-O3 -march=native $CFLAGS" CXXFLAGS="-O3 -march=native $CXXFLAGS" cmake -DCMAKE_BUILD_TYPE=Release -DDNNL_GPU_RUNTIME=OCL MKLDNN_ARCH_OPT_FLAGS="-O3 -march=native $CFLAGS" $CMAKE_OPTIONS ..
-make -j $NUM_CPU_CORES
+make -j $NUM_CPU_PHYSICAL_CORES
 EXIT_STATUS=$?
 if [ $EXIT_STATUS -ne 0 ]; then
 	# For architectures not supporting -march=native compiler option...
 	CFLAGS="-O3 $CFLAGS" CXXFLAGS="-O3 $CXXFLAGS" cmake -DCMAKE_BUILD_TYPE=Release -DDNNL_GPU_RUNTIME=OCL MKLDNN_ARCH_OPT_FLAGS="-O3 $CFLAGS" $CMAKE_OPTIONS ..
-	make -j $NUM_CPU_CORES
+	make -j $NUM_CPU_PHYSICAL_CORES
 	EXIT_STATUS=$?
 fi
 echo $EXIT_STATUS > ~/install-exit-status
 cd ~
-echo "#!/bin/bash
+cat <<'EOF' > onednn
+#!/bin/bash
+# setting non-zero status if any of pipeline operations fail 
+set -o pipefail
+# Benchmark harness expects 0, all exit codes must be 0 to pass
+# Dumping and replacing non-zero code(s) to fail the run
+update_test_exit_status() {
+	[ $1 -ne 0 ] && echo $1 > ~/test-exit-status;
+}
+# Debug variables to run without PTS
+LOG_FILE=${LOG_FILE:="`pwd`/onednn.log"}
+NUM_CPU_PHYSICAL_CORES=${NUM_CPU_PHYSICAL_CORES:-`lscpu | awk '/^Core\(s\) per socket:/ {cores=$4} /^Socket\(s\):/ {sockets=$2} END {print cores*sockets}'`}
+# oneDNN threading setup
 export DNNL_CPU_RUNTIME=OMP
 export OMP_PLACES=cores
 export OMP_PROC_BIND=close
-cd oneDNN-3.8.1/build/tests/benchdnn
-./benchdnn \$4 --mode=p \$1 \$3 \$2 > \$LOG_FILE 2>&1
-echo \$? > ~/test-exit-status" > onednn
+export OMP_WAIT_POLICY=ACTIVE 
+# Here and below OMP_NUM_THREADS should match physical cores used by a process
+# otherwise OpenMP will pin several threads to a core which will lead to a huge oversubscription 
+export OMP_NUM_THREADS=$NUM_CPU_PHYSICAL_CORES
+cd oneDNN-3.11.1/build/tests/benchdnn
+ONEDNN_COMPUTE_NODES=(${ONEDNN_COMPUTE_NODES:=`numactl -H | grep -E "cpus: [0-9]" | awk '{print $2}' | tr '\n' ' '`})
+ONEDNN_COMPUTE_NODE_COUNT=${#ONEDNN_COMPUTE_NODES[@]}
+
+if [ "$4" == "--engine=cpu" ] && [ $ONEDNN_COMPUTE_NODE_COUNT -gt 1 ]
+then
+	# Following oneDNN documentation recommendation
+	# https://www.intel.com/content/www/us/en/docs/onednn/developer-guide-reference/2025-2/configuring-onednn-for-benchmarking.html
+	# oneDNN benchmarking recommendations:
+	# * Modern CPUs may have multiple hardware threads per CPU core enabled. Such threads are usually exposed by OS as additional logical processors ...
+	#   If this is the case, the recommendation is to use only one of hardware threads per core.
+	# * Single NUMA domain. This setup is the recommended one.
+	# So if NUMA compute nodes are available then 
+	# * Running 1 benchmark instance per NUMA compute node.
+	# * Providing aggregated values to the benchmark harness. See below comments for details.
+	echo $? > ~/test-exit-status
+	update_test_exit_status $?
+	for i in "${ONEDNN_COMPUTE_NODES[@]}";do
+		# Get physical cores on the compute node
+		CORES=`lscpu -e=CPU,CORE,NODE | awk -v node=$i '$3==node && !seen[$2]++ {printf "%s,",$1}' | sed 's/,$//'`
+		# The function is not thread-safe, running sequentially 
+		update_test_exit_status $?
+		( OMP_NUM_THREADS=$(echo "$CORES" | tr ',' ' ' |  wc -w ) numactl -C $CORES ./benchdnn --mode=p $1 --perf-template=GFLOPS:%-Gflops% $3 $2 $4 2>&1 | grep -oP 'GFLOPS:\K[0-9.]+' | awk '{sum += $1; n++; print $1} END {printf "Result: %.7e GFLOPS\n", sum/n}' > $LOG_FILE.$i.txt; echo $? > $LOG_FILE.test-exit-status.$i.txt ) &
+	done;
+	wait
+	rm $LOG_FILE.sum.txt 2>/dev/null
+	for i in "${ONEDNN_COMPUTE_NODES[@]}";do
+		# Dump logs from instances into one file
+		cat $LOG_FILE.$i.txt >> $LOG_FILE.sum.txt
+		# Collect error codes from sub-shells
+		update_test_exit_status $(cat $LOG_FILE.test-exit-status.$i.txt 2>/dev/null)
+	done;
+	# Dumping aggregated values
+	# Cumulative throughput, a average of Gflops of all operations in the requested batch accumulated across all NUMA nodes
+	grep "Result:" $LOG_FILE.sum.txt | awk '{s+=$2}END{printf "\nResult: %.7e GFLOPS\n", s}' >> $LOG_FILE
+	update_test_exit_status $?
+	echo "" >> $LOG_FILE
+	rm $LOG_FILE.*.txt
+else
+	# Result is an average of Gflops of all operations in the requested batch
+	./benchdnn --mode=p $1 --perf-template=GFLOPS:%-Gflops% $3 $2 $4 2>&1 | grep -oP 'GFLOPS:\K[0-9.]+' | awk '{sum += $1; n++; print $1} END {printf "\nResult: %.7e GFLOPS\n", sum/n}'  > $LOG_FILE 2>&1
+	echo $? > ~/test-exit-status
+fi
+# clean-up pipefail 
+set +o pipefail
+EOF
 chmod +x onednn

--- a/ob-cache/test-profiles/pts/onednn-3.8.0/results-definition.xml
+++ b/ob-cache/test-profiles/pts/onednn-3.8.0/results-definition.xml
@@ -2,8 +2,7 @@
 <!--Phoronix Test Suite v10.8.5-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate>total perf  min(ms) #_MIN_RESULT_# avg(ms) #_RESULT_#</OutputTemplate>
-    <LineHint>total perf</LineHint>
-    <TurnCharsToSpace>:</TurnCharsToSpace>
+    <OutputTemplate>Result: #_RESULT_# GFLOPS</OutputTemplate>
+    <LineHint>Result:</LineHint>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/ob-cache/test-profiles/pts/onednn-3.8.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/onednn-3.8.0/test-definition.xml
@@ -3,14 +3,14 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>oneDNN</Title>
-    <AppVersion>3.8.1</AppVersion>
+    <AppVersion>3.11</AppVersion>
     <Description>This is a test of the Intel oneDNN as an Intel-optimized library for Deep Neural Networks and making use of its built-in benchdnn functionality. The result is the total perf time reported. Intel oneDNN was formerly known as DNNL (Deep Neural Network Library) and MKL-DNN before being rebranded as part of the Intel oneAPI toolkit and since part of the UXL Foundation.</Description>
-    <ResultScale>ms</ResultScale>
-    <Proportion>LIB</Proportion>
+    <ResultScale>GFLOPS</ResultScale>
+    <Proportion>HIB</Proportion>
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>3.8.0</Version>
+    <Version>3.11.0</Version>
     <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
     <SoftwareType>Utility</SoftwareType>
     <TestType>Processor</TestType>
@@ -29,32 +29,34 @@
       <Identifier>harness</Identifier>
       <Menu>
         <Entry>
-          <Name>Convolution Batch Shapes Auto</Name>
-          <Value>--conv --batch=inputs/conv/shapes_auto</Value>
+          <Name>Convolution Batch Shapes</Name>
+          <Value>--conv --batch=inputs/conv/shapes_perf_basic</Value>
         </Entry>
         <Entry>
-          <Name>Deconvolution Batch shapes_1d</Name>
-          <Value>--deconv --batch=inputs/deconv/shapes_1d</Value>
+          <Name>Matmul Batch Shapes</Name>
+          <Value>--matmul --batch=inputs/matmul/shapes_perf_basic</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Data Type</DisplayName>
+      <Identifier>data_type</Identifier>
+      <Menu>
+        <Entry>
+          <Name>FP32</Name>
+          <Value>--dt=f32</Value>
         </Entry>
         <Entry>
-          <Name>Deconvolution Batch shapes_3d</Name>
-          <Value>--deconv --batch=inputs/deconv/shapes_3d</Value>
+          <Name>FP16</Name>
+          <Value>--dt=f16</Value>
         </Entry>
         <Entry>
-          <Name>IP Shapes 1D</Name>
-          <Value>--ip --batch=inputs/ip/shapes_1d</Value>
+          <Name>BF16</Name>
+          <Value>--dt=bf16</Value>
         </Entry>
         <Entry>
-          <Name>IP Shapes 3D</Name>
-          <Value>--ip --batch=inputs/ip/shapes_3d</Value>
-        </Entry>
-        <Entry>
-          <Name>Recurrent Neural Network Training</Name>
-          <Value>--rnn --batch=inputs/rnn/perf_rnn_training</Value>
-        </Entry>
-        <Entry>
-          <Name>Recurrent Neural Network Inference</Name>
-          <Value>--rnn --batch=inputs/rnn/perf_rnn_inference_lb</Value>
+          <Name>INT8</Name>
+          <Value>--dt=s8</Value>
         </Entry>
       </Menu>
     </Option>


### PR DESCRIPTION
### Updating oneDNN from v3.8.1 to v3.11.1
### Switching the benchmark metrics from Latency (ms) to Throughput (GFLOPS)
### Adding NUMA awareness:
if NUMA compute nodes are available then
- Running 1 benchmark instance per NUMA compute node.
- Providing aggregated values to the benchmark harness (Cumulative throughput from all NUMA nodes)

oneDNN benchmarking recommendations https://uxlfoundation.github.io/oneDNN/v3.11/dev_guide_performance_settings.html
- Modern CPUs may have multiple hardware threads per CPU core enabled. Such threads are usually exposed by OS as additional logical processors … If this is the case, the recommendation is to use only one of hardware threads per core.
- Single NUMA domain. This setup is the recommended one.

### Adding AI datatypes. In addition to FP32
- FP16 - IEEE-754 half precision
- BF16 - Brain floating point
- INT8 - Result of INT8 Quantization

### Updating workloads in the benchmark. Input from the oneDNN team:
2 benchdnn input files were added to oneDNN repository
- **Convolution Batch Shapes:** tests/benchdnn/inputs/conv/shapes_perf_basic
- **MatMul Batch Shapes:** tests/benchdnn/inputs/matmul/shapes_perf_basic

They contain a list of shapes from MLPerf benchmarks
- Resnet50
- Mobilenet v1
- 3DUnet
- BERT Large
- DLRM v2
- Vision Transformer
- Deep Seek

Also added shapes from Stable Diffusion as an example of small generative AI model. 
Shapes are selected to cover diverse use cases like first convolution, depthwise convolution, 3d spatial and 1x1 and non-1x1 kernel. For matmul they cover batched 3d matmul and 2d cases and different ratio between M/N/K.
