### PR TITLE
TensorFlow: adding distributed training and adjusting batch sizes

### DIFF
--- a/ob-cache/test-profiles/pts/tensorflow-2.3.0/install.sh
+++ b/ob-cache/test-profiles/pts/tensorflow-2.3.0/install.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 pip3 install --user tensorflow-cpu==2.20.0
+# horovod fails to build by gcc 13+, using "independent" performance runs
+# HOROVOD_WITH_TENSORFLOW=1 pip3 install --no-cache-dir horovod
 echo $? > ~/install-exit-status
 unzip -o tensorflow-benchmarks-8fb79079265933ad39bea628b777af662f5bf15d.zip
 # Compatibility workarounds for TensorFlow 2.16...
@@ -7,10 +9,27 @@ sed -i '126d' benchmarks-8fb79079265933ad39bea628b777af662f5bf15d/scripts/tf_cnn
 sed -i '126d' benchmarks-8fb79079265933ad39bea628b777af662f5bf15d/scripts/tf_cnn_benchmarks/models/experimental/deepspeech.py
 sed -i '126d' benchmarks-8fb79079265933ad39bea628b777af662f5bf15d/scripts/tf_cnn_benchmarks/models/experimental/deepspeech.py
 sed -i 's/use_tf_layers = use_tf_layers/use_tf_layers = False/g' benchmarks-8fb79079265933ad39bea628b777af662f5bf15d/scripts/tf_cnn_benchmarks/convnet_builder.py
-echo "#!/bin/sh
+cat <<'EOF' > tensorflow
+#!/bin/bash
+
+# OpenMPI variables
+# --allow-run-as-root is not supported by MPICH and Intel MPI
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+# These args are ignored by MPICH and Intel MPI so safe to pass to mpirun
+export OMPI_MORE_ARGS="--map-by numa --bind-to numa"
+# Intel MPI variables
+export I_MPI_PIN_CELL=unit
+export I_MPI_PIN_DOMAIN=numa
+
 cd benchmarks-8fb79079265933ad39bea628b777af662f5bf15d/scripts/tf_cnn_benchmarks/
-python3 tf_cnn_benchmarks.py \$@ > \$LOG_FILE 2>&1
-echo \$? > ~/test-exit-status" > tensorflow
+
+# By default TF_BENCH_RANK_COUNT is NUMA count
+TF_BENCH_RANK_COUNT=${TF_BENCH_RANK_COUNT:=`numactl -H 2>/dev/null| grep -c -E "cpus: [0-9]"`}
+if [ "$3" == "gpu" ] || [ $TF_BENCH_RANK_COUNT -lt 1 ]; then TF_BENCH_RANK_COUNT=1; fi  # GPU / no NUMA / no numactl / incorect external TF_BENCH_RANK_COUNT value
+mpirun -n $TF_BENCH_RANK_COUNT $OMPI_MORE_ARGS python3 tf_cnn_benchmarks.py --variable_update=independent --num_batches=50 $@ > $LOG_FILE 2>&1
+echo $? > ~/test-exit-status
+# PTS harness reads last value by default so put aggregated results to the full $LOG_FILE for debug purposes
+grep -oP 'total images/sec: [0-9.]+' $LOG_FILE | awk '{sum += $3; print $3} END {printf "total images/sec: %f\n", sum}' >> $LOG_FILE
+EOF
 chmod +x tensorflow
-
-

--- a/ob-cache/test-profiles/pts/tensorflow-2.3.0/test-definition.xml
+++ b/ob-cache/test-profiles/pts/tensorflow-2.3.0/test-definition.xml
@@ -16,11 +16,11 @@
     <TestType>System</TestType>
     <License>Free</License>
     <Status>Verified</Status>
-    <ExternalDependencies>python</ExternalDependencies>
+    <ExternalDependencies>python openmpi-development</ExternalDependencies>
     <EnvironmentSize>1300</EnvironmentSize>
     <ProjectURL>https://www.tensorflow.org/</ProjectURL>
     <RepositoryURL>https://github.com/tensorflow/tensorflow</RepositoryURL>
-    <InternalTags>SMP</InternalTags>
+    <InternalTags>SMP, MPI</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
     <SystemDependencies>pip3</SystemDependencies>
   </TestProfile>
@@ -49,20 +49,12 @@
       <ArgumentPrefix>--batch_size=</ArgumentPrefix>
       <Menu>
         <Entry>
-          <Name>1</Name>
-          <Value>1</Value>
-        </Entry>
-        <Entry>
-          <Name>16</Name>
-          <Value>16</Value>
-        </Entry>
-        <Entry>
-          <Name>32</Name>
-          <Value>32</Value>
-        </Entry>
-        <Entry>
           <Name>64</Name>
           <Value>64</Value>
+        </Entry>
+        <Entry>
+          <Name>128</Name>
+          <Value>128</Value>
         </Entry>
         <Entry>
           <Name>256</Name>


### PR DESCRIPTION
### Adding distributed training
Adding distributed training, by default it is NUMA-bound. There are several ways of distributed training supported by the tf_cnn_benchmarks benchmark. Since the latest horovod release lacks the support of gcc 13+ compilers (https://github.com/horovod/horovod/pull/3957) using simple "independent" performance check method of the benchmark that does not reduce/share gradients between training instances.

### Adjusting batch sizes
Low batch sizes (1,2,etc.) are useless for training so setting lower batch size to 64, the lowest default batch size across models used in the benchmark (resnet-50).
