### PR TITLE
bash_completion: don't use the deprecated `have`

### DIFF
--- a/pts-core/static/bash_completion
+++ b/pts-core/static/bash_completion
@@ -1,4 +1,3 @@
-have phoronix-test-suite &&
 _phoronix_test_suite_show()
 {
         local cur


### PR DESCRIPTION
It's deprecated
https://github.com/scop/bash-completion/blob/9b3c713db161245a08a05a546f657d8cfa7bc92c/bash_completion.d/000_bash_completion_compat.bash#L53-L54