### PR TITLE
gentoo-packages.xml: remove wrong maven node

### DIFF
--- a/pts-core/external-test-dependencies/xml/gentoo-packages.xml
+++ b/pts-core/external-test-dependencies/xml/gentoo-packages.xml
@@ -86,10 +86,6 @@
 			<PackageName>dev-lang/maven-bin</PackageName>
 		</Package>
 		<Package>
-			<GenericName>maven</GenericName>
-			<PackageName>maven</PackageName>
-		</Package>
-		<Package>
 			<GenericName>nasm</GenericName>
 			<PackageName>dev-lang/nasm</PackageName>
 		</Package>


### PR DESCRIPTION
maven-bin is there, it probably is a leftover