### PR TITLE
ubuntu-pts-docker-build.sh: use posix sh

### DIFF
--- a/deploy/docker/ubuntu-pts-docker-build.sh
+++ b/deploy/docker/ubuntu-pts-docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 export TESTS_TO_PRECACHE=""
 


### PR DESCRIPTION
The script does not use any bash specific features so posix sh should be used