### PR TITLE
ubuntu-pts-docker-build.sh: use ENTRYPOINT

### DIFF
--- a/deploy/docker/ubuntu-pts-docker-build.sh
+++ b/deploy/docker/ubuntu-pts-docker-build.sh
@@ -44,7 +44,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt install -y unzip php-cli apt-utils mesa-utils php-xml git-core apt-file sudo
 RUN apt-file update
-CMD ["/phoronix-test-suite/phoronix-test-suite", "shell"]
+ENTRYPOINT ["/phoronix-test-suite/phoronix-test-suite"]
+CMD ["shell"]
 EOF
 
 docker build -t $DIR_NAME .


### PR DESCRIPTION
follows the best practices:
https://www.docker.com/blog/docker-best-practices-choosing-between-run-cmd-and-entrypoint/#:~:text=CMD%20and%20ENTRYPOINT

This can break compatibility though