### PR TITLE
ACES DGEMM: build simplification and OpenMP fixes

### DIFF
--- a/ob-cache/test-profiles/pts/mt-dgemm-1.3.1/install.sh
+++ b/ob-cache/test-profiles/pts/mt-dgemm-1.3.1/install.sh
@@ -6,21 +6,18 @@ cd OpenBLAS-2e2f952bfbe92074db50ae1191afabc63deb510a
 make NUM_THREADS=1024 USE_THREAD=1 USE_OPENMP=1 DYNAMIC_ARCH=1 -j $NUM_CPU_CORES
 make PREFIX=$HOME/openblas_ NUM_THREADS=1024 USE_THREAD=1 USE_OPENMP=1 DYNAMIC_ARCH=1 install
 cd ~
-if [ $OS_TYPE = "Linux" ]
-then
-    if grep avx2 /proc/cpuinfo > /dev/null
-    then
-	export CFLAGS="$CFLAGS -mavx2"
-    fi
-fi
-cc -ffast-math $CFLAGS -ftree-vectorizer-verbose=3 -O3 -fopenmp -DUSE_CBLAS -I./openblas_/include -o mtdgemm mt-dgemm/src/mt-dgemm.c -L./openblas_/lib -lopenblas
+cc -march=native -ffast-math $CFLAGS -ftree-vectorizer-verbose=3 -O3 -fopenmp -DUSE_CBLAS -I./openblas_/include -o mtdgemm mt-dgemm/src/mt-dgemm.c -L./openblas_/lib -lopenblas
 echo $? > ~/install-exit-status
 rm -rf mt-dgemm
-echo "#!/bin/sh
-export OMP_NUM_THREADS=\$NUM_CPU_CORES
+cat <<'EOF' > mt-dgemm
+#!/bin/sh
+export OMP_NUM_THREADS=$NUM_CPU_PHYSICAL_CORES
 export OMP_PLACES=cores
 export OMP_PROC_BIND=close
-export LD_LIBRARY_PATH=./openblas_/lib:\$LD_LIBRARY_PATH
-./mtdgemm \$@ > \$LOG_FILE 2>&1
-echo \$? > ~/test-exit-status" > mt-dgemm
+export OMP_SCHEDULE=STATIC
+export OMP_WAIT_POLICY=ACTIVE
+export LD_LIBRARY_PATH=./openblas_/lib:$LD_LIBRARY_PATH
+./mtdgemm $@ > $LOG_FILE 2>&1
+echo $? > ~/test-exit-status
+EOF
 chmod +x mt-dgemm


### PR DESCRIPTION
 Fixes: 
1. Build simplified, replaced machine capability diagnostics with simple "-march=native"
2. OpenMP settings fixed: old version puts 2 GOMP threads to one logical core when SMT enabled