### PR TITLE
Add override env vars for gpu metrics

### DIFF
--- a/documentation/phoronix-test-suite.html
+++ b/documentation/phoronix-test-suite.html
@@ -1150,6 +1150,30 @@ The variable is relevant for: test installation.
 <p>The value can be of type: string.
 The variable is relevant for: test execution / benchmarking.
 </p>
+<h2>PTS_GPU_FREQ_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU frequency sensor. Set it to an absolute readable GPU frequency path, such as a gt_cur_freq_mhz or pp_dpm_sclk sysfs file, when the default GPU frequency paths are not detected. The value is expected to report Megahertz or use the active pp_dpm_sclk line format.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_MEMORY_USAGE_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU memory usage sensor. Set it to an absolute readable memory usage path, such as /sys/class/drm/card0/device/mem_info_vram_used, when the default GPU memory usage paths are not detected. Values greater than 1000000 are treated as bytes and converted to Megabytes.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_POWER_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU power sensor. Set it to an absolute readable hwmon power input path, such as /sys/class/drm/card1/device/hwmon/hwmon4/power1_input, when the default GPU power paths are not detected. The value is expected to report microwatts as Linux hwmon power*_input and power*_average files do.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_TEMP_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU temperature sensor. Set it to an absolute readable hwmon temperature input path, such as a temp*_input file, when the default GPU temperature paths are not detected. Values greater than 1000 are treated as millidegrees Celsius and converted to Celsius.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_USAGE_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU usage sensor. Set it to an absolute readable GPU usage path, such as /sys/class/drm/card0/device/gpu_busy_percent, when the default GPU usage paths are not detected. The value is expected to report a percentage from 0 to 100.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_VOLTAGE_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU voltage sensor. Set it to an absolute readable hwmon voltage input path, such as an in*_input file, when the default GPU voltage paths are not detected. The value is expected to report millivolts.</em></p>
+<p>The value can be of type: string.
+</p>
 <h2>PTS_IGNORE_MODULES</h2>
 <p><em>Enabling this option can be used for temporarily disabling Phoronix Test Suite modules from being loaded on a given run. This is primarily for debugging purposes.</em></p>
 <p>The value can be of type: boolean (TRUE / FALSE).

--- a/documentation/phoronix-test-suite.md
+++ b/documentation/phoronix-test-suite.md
@@ -1339,6 +1339,42 @@ The value can be of type: string.
 The variable is relevant for: test execution / benchmarking.
 
 
+### PTS_GPU_FREQ_INPUT_PATH
+*This option can be used for overriding the Linux sysfs file used for the GPU frequency sensor. Set it to an absolute readable GPU frequency path, such as a gt_cur_freq_mhz or pp_dpm_sclk sysfs file, when the default GPU frequency paths are not detected. The value is expected to report Megahertz or use the active pp_dpm_sclk line format.*
+
+The value can be of type: string.
+
+
+### PTS_GPU_MEMORY_USAGE_INPUT_PATH
+*This option can be used for overriding the Linux sysfs file used for the GPU memory usage sensor. Set it to an absolute readable memory usage path, such as /sys/class/drm/card0/device/mem_info_vram_used, when the default GPU memory usage paths are not detected. Values greater than 1000000 are treated as bytes and converted to Megabytes.*
+
+The value can be of type: string.
+
+
+### PTS_GPU_POWER_INPUT_PATH
+*This option can be used for overriding the Linux sysfs file used for the GPU power sensor. Set it to an absolute readable hwmon power input path, such as /sys/class/drm/card1/device/hwmon/hwmon4/power1_input, when the default GPU power paths are not detected. The value is expected to report microwatts as Linux hwmon power*_input and power*_average files do.*
+
+The value can be of type: string.
+
+
+### PTS_GPU_TEMP_INPUT_PATH
+*This option can be used for overriding the Linux sysfs file used for the GPU temperature sensor. Set it to an absolute readable hwmon temperature input path, such as a temp*_input file, when the default GPU temperature paths are not detected. Values greater than 1000 are treated as millidegrees Celsius and converted to Celsius.*
+
+The value can be of type: string.
+
+
+### PTS_GPU_USAGE_INPUT_PATH
+*This option can be used for overriding the Linux sysfs file used for the GPU usage sensor. Set it to an absolute readable GPU usage path, such as /sys/class/drm/card0/device/gpu_busy_percent, when the default GPU usage paths are not detected. The value is expected to report a percentage from 0 to 100.*
+
+The value can be of type: string.
+
+
+### PTS_GPU_VOLTAGE_INPUT_PATH
+*This option can be used for overriding the Linux sysfs file used for the GPU voltage sensor. Set it to an absolute readable hwmon voltage input path, such as an in*_input file, when the default GPU voltage paths are not detected. The value is expected to report millivolts.*
+
+The value can be of type: string.
+
+
 ### PTS_IGNORE_MODULES
 *Enabling this option can be used for temporarily disabling Phoronix Test Suite modules from being loaded on a given run. This is primarily for debugging purposes.*
 

--- a/documentation/stubs/42_env_vars.html
+++ b/documentation/stubs/42_env_vars.html
@@ -156,6 +156,30 @@ The variable is relevant for: test installation.
 <p>The value can be of type: string.
 The variable is relevant for: test execution / benchmarking.
 </p>
+<h2>PTS_GPU_FREQ_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU frequency sensor. Set it to an absolute readable GPU frequency path, such as a gt_cur_freq_mhz or pp_dpm_sclk sysfs file, when the default GPU frequency paths are not detected. The value is expected to report Megahertz or use the active pp_dpm_sclk line format.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_MEMORY_USAGE_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU memory usage sensor. Set it to an absolute readable memory usage path, such as /sys/class/drm/card0/device/mem_info_vram_used, when the default GPU memory usage paths are not detected. Values greater than 1000000 are treated as bytes and converted to Megabytes.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_POWER_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU power sensor. Set it to an absolute readable hwmon power input path, such as /sys/class/drm/card1/device/hwmon/hwmon4/power1_input, when the default GPU power paths are not detected. The value is expected to report microwatts as Linux hwmon power*_input and power*_average files do.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_TEMP_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU temperature sensor. Set it to an absolute readable hwmon temperature input path, such as a temp*_input file, when the default GPU temperature paths are not detected. Values greater than 1000 are treated as millidegrees Celsius and converted to Celsius.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_USAGE_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU usage sensor. Set it to an absolute readable GPU usage path, such as /sys/class/drm/card0/device/gpu_busy_percent, when the default GPU usage paths are not detected. The value is expected to report a percentage from 0 to 100.</em></p>
+<p>The value can be of type: string.
+</p>
+<h2>PTS_GPU_VOLTAGE_INPUT_PATH</h2>
+<p><em>This option can be used for overriding the Linux sysfs file used for the GPU voltage sensor. Set it to an absolute readable hwmon voltage input path, such as an in*_input file, when the default GPU voltage paths are not detected. The value is expected to report millivolts.</em></p>
+<p>The value can be of type: string.
+</p>
 <h2>PTS_IGNORE_MODULES</h2>
 <p><em>Enabling this option can be used for temporarily disabling Phoronix Test Suite modules from being loaded on a given run. This is primarily for debugging purposes.</em></p>
 <p>The value can be of type: boolean (TRUE / FALSE).

--- a/pts-core/objects/phodevi/sensors/gpu_freq.php
+++ b/pts-core/objects/phodevi/sensors/gpu_freq.php
@@ -26,13 +26,20 @@ class gpu_freq extends phodevi_sensor
 	const SENSOR_TYPE = 'gpu';
 	const SENSOR_SENSES = 'freq';
 	const SENSOR_UNIT = 'Megahertz';
+	const INPUT_PATH_ENV = 'PTS_GPU_FREQ_INPUT_PATH';
 
 	public function read_sensor()
 	{
 		// Graphics processor real/current frequency
 		$show_memory = false;
-		$core_freq = 0;
+		$core_freq = self::read_freq_input(pts_env::read(self::INPUT_PATH_ENV));
 		$mem_freq = 0;
+
+		if($core_freq > 0)
+		{
+			return $core_freq;
+		}
+		$core_freq = 0;
 
 		if(phodevi::is_nvidia_graphics()) // NVIDIA GPU
 		{
@@ -199,6 +206,34 @@ class gpu_freq extends phodevi_sensor
 		}
 
 		return $show_memory ? array($core_freq, $mem_freq) : $core_freq;
+	}
+
+	private static function read_freq_input($freq_input_file)
+	{
+		if($freq_input_file == false || !is_readable($freq_input_file))
+		{
+			return -1;
+		}
+
+		$freq = pts_file_io::file_get_contents($freq_input_file);
+		if(is_numeric($freq))
+		{
+			return $freq > 0 ? $freq : -1;
+		}
+
+		$freq = PHP_EOL . $freq;
+		if(strpos($freq, '*') !== false)
+		{
+			$freq = substr($freq, 0, strpos($freq, '*'));
+			$freq = substr($freq, strrpos($freq, PHP_EOL));
+			if(($x = strpos($freq, ': ')) !== false)
+			{
+				$freq = substr($freq, $x + 2);
+			}
+			$freq = trim(str_ireplace(array('*', 'Mhz'), '', $freq));
+		}
+
+		return is_numeric($freq) && $freq > 0 ? $freq : -1;
 	}
 }
 

--- a/pts-core/objects/phodevi/sensors/gpu_memory_usage.php
+++ b/pts-core/objects/phodevi/sensors/gpu_memory_usage.php
@@ -25,10 +25,16 @@ class gpu_memory_usage extends phodevi_sensor
 	const SENSOR_TYPE = 'gpu';
 	const SENSOR_SENSES = 'memory-usage';
 	const SENSOR_UNIT = 'Megabytes';
+	const INPUT_PATH_ENV = 'PTS_GPU_MEMORY_USAGE_INPUT_PATH';
 
 	public function read_sensor()
 	{
-		$mem_usage = -1;
+		$mem_usage = self::read_memory_usage_input(pts_env::read(self::INPUT_PATH_ENV));
+
+		if($mem_usage != -1)
+		{
+			return $mem_usage;
+		}
 
 		if(($nvidia_smi = pts_client::executable_in_path('nvidia-smi')))
 		{
@@ -60,6 +66,22 @@ class gpu_memory_usage extends phodevi_sensor
 		}
 
 		return $mem_usage;
+	}
+
+	private static function read_memory_usage_input($memory_usage_input_file)
+	{
+		if($memory_usage_input_file == false || !is_readable($memory_usage_input_file))
+		{
+			return -1;
+		}
+
+		$memory_usage = pts_file_io::file_get_contents($memory_usage_input_file);
+		if(is_numeric($memory_usage) && $memory_usage >= 0)
+		{
+			return $memory_usage > 1000000 ? floor($memory_usage / 1000000) : $memory_usage;
+		}
+
+		return -1;
 	}
 }
 

--- a/pts-core/objects/phodevi/sensors/gpu_power.php
+++ b/pts-core/objects/phodevi/sensors/gpu_power.php
@@ -24,16 +24,47 @@ class gpu_power extends phodevi_sensor
 {
 	const SENSOR_TYPE = 'gpu';
 	const SENSOR_SENSES = 'power';
+	const INPUT_PATH_ENV = 'PTS_GPU_POWER_INPUT_PATH';
 	private static $unit = 'Milliwatts';
 
 	public static function get_unit()
 	{
 		return self::$unit;
 	}
+	private static function read_hwmon_power_input($power_input_file)
+	{
+		if($power_input_file == false || !is_readable($power_input_file))
+		{
+			return -1;
+		}
+
+		$power_input = pts_file_io::file_get_contents($power_input_file);
+		return self::micro_watts_to_watts($power_input);
+	}
+	private static function micro_watts_to_watts($power_input)
+	{
+		if(is_numeric($power_input))
+		{
+			$power_input = $power_input / 1000000;
+			if($power_input > 0 && $power_input < 900)
+			{
+				self::$unit = 'Watts';
+				return $power_input;
+			}
+		}
+
+		return -1;
+	}
 	public function read_sensor()
 	{
+		self::$unit = 'Milliwatts';
 		$gpu_power = -1;
-		$en1_input_files = glob('/sys/class/drm/card*/device/hwmon/hwmon*/energy1_input');
+		if(($gpu_power = self::read_hwmon_power_input(pts_env::read(self::INPUT_PATH_ENV))) != -1)
+		{
+			return $gpu_power;
+		}
+
+		$en1_input_files = pts_file_io::glob('/sys/class/drm/card*/device/hwmon/hwmon*/energy1_input');
 		if(($nvidia_smi = pts_client::executable_in_path('nvidia-smi')))
 		{
 			$smi_output = shell_exec(escapeshellarg($nvidia_smi) . ' -q -d POWER');
@@ -73,15 +104,7 @@ class gpu_power extends phodevi_sensor
 		else if($power1_average = phodevi_linux_parser::read_sysfs_node('/sys/class/drm/card*/device/hwmon/hwmon*/power1_average', 'POSITIVE_NUMERIC'))
 		{
 			// AMDGPU path
-			if(is_numeric($power1_average))
-			{
-				$power1_average = $power1_average / 1000000;
-				if($power1_average > 0 && $power1_average < 900)
-				{
-					self::$unit = 'Watts';
-					$gpu_power = $power1_average;
-				}
-			}
+			$gpu_power = self::micro_watts_to_watts($power1_average);
 		}
 		else if(is_readable('/sys/kernel/debug/dri/0/i915_emon_status'))
 		{

--- a/pts-core/objects/phodevi/sensors/gpu_temp.php
+++ b/pts-core/objects/phodevi/sensors/gpu_temp.php
@@ -25,13 +25,35 @@ class gpu_temp extends phodevi_sensor
 	const SENSOR_TYPE = 'gpu';
 	const SENSOR_SENSES = 'temp';
 	const SENSOR_UNIT = 'Celsius';
+	const INPUT_PATH_ENV = 'PTS_GPU_TEMP_INPUT_PATH';
+
+	private static function read_temp_input($temp_input_file)
+	{
+		if($temp_input_file == false || !is_readable($temp_input_file))
+		{
+			return -1;
+		}
+
+		$temp_input = pts_file_io::file_get_contents($temp_input_file);
+		if(is_numeric($temp_input))
+		{
+			if($temp_input > 1000)
+			{
+				$temp_input /= 1000;
+			}
+
+			return $temp_input;
+		}
+
+		return -1;
+	}
 
 	public function read_sensor()
 	{
 		// Report graphics processor temperature
-		$temp_c = -1;
+		$temp_c = self::read_temp_input(pts_env::read(self::INPUT_PATH_ENV));
 
-		if(phodevi::is_nvidia_graphics())
+		if($temp_c == -1 && phodevi::is_nvidia_graphics())
 		{
 			$temp_c = phodevi_parser::read_nvidia_extension('GPUCoreTemp');
 		}
@@ -46,16 +68,8 @@ class gpu_temp extends phodevi_sensor
 					continue;
 				}
 
-				$temp_input = pts_file_io::file_get_contents($temp_input);
-
-				if(is_numeric($temp_input))
-				{
-					if($temp_input > 1000)
+				if(($temp_c = self::read_temp_input($temp_input)) != -1)
 					{
-						$temp_input /= 1000;
-					}
-
-					$temp_c = $temp_input;
 					break;
 				}
 			}
@@ -99,16 +113,8 @@ class gpu_temp extends phodevi_sensor
 						continue;
 					}
 
-					$temp_input = pts_file_io::file_get_contents($temp_input_file);
-
-					if(is_numeric($temp_input))
-					{
-						if($temp_input > 1000)
+					if(($temp_c = self::read_temp_input($temp_input_file)) != -1)
 						{
-							$temp_input /= 1000;
-						}
-
-						$temp_c = $temp_input;
 						break;
 					}
 				}

--- a/pts-core/objects/phodevi/sensors/gpu_usage.php
+++ b/pts-core/objects/phodevi/sensors/gpu_usage.php
@@ -27,6 +27,7 @@ class gpu_usage extends phodevi_sensor
 	const SENSOR_TYPE = 'gpu';
 	const SENSOR_SENSES = 'usage';
 	const SENSOR_UNIT = 'Percent';
+	const INPUT_PATH_ENV = 'PTS_GPU_USAGE_INPUT_PATH';
 
 	private $probe_radeontop = false;
 	private $probe_nvidia_smi = false;
@@ -36,7 +37,10 @@ class gpu_usage extends phodevi_sensor
 	{
 		parent::__construct($instance, $parameter);
 
+		if(self::read_usage_input(pts_env::read(self::INPUT_PATH_ENV)) == -1)
+		{
 		$this->set_probe_mode();
+		}
 	}
 
 	public function support_check()
@@ -47,7 +51,16 @@ class gpu_usage extends phodevi_sensor
 
 	public function read_sensor()
 	{
-		$gpu_usage = -1;
+		$gpu_usage = self::read_usage_input(pts_env::read(self::INPUT_PATH_ENV));
+
+		if($gpu_usage != -1)
+		{
+			return $gpu_usage;
+		}
+		if(!$this->probe_nvidia_settings && !$this->probe_nvidia_smi && !$this->probe_radeontop)
+		{
+			$this->set_probe_mode();
+		}
 
 		if($this->probe_nvidia_settings)
 		{
@@ -67,6 +80,17 @@ class gpu_usage extends phodevi_sensor
 		}
 
 		return $gpu_usage;
+	}
+
+	private static function read_usage_input($usage_input_file)
+	{
+		if($usage_input_file == false || !is_readable($usage_input_file))
+		{
+			return -1;
+		}
+
+		$usage = pts_file_io::file_get_contents($usage_input_file);
+		return is_numeric($usage) && $usage >= 0 && $usage <= 100 ? $usage : -1;
 	}
 
 	private function set_probe_mode()

--- a/pts-core/objects/phodevi/sensors/gpu_voltage.php
+++ b/pts-core/objects/phodevi/sensors/gpu_voltage.php
@@ -25,10 +25,16 @@ class gpu_voltage extends phodevi_sensor
 	const SENSOR_TYPE = 'gpu';
 	const SENSOR_SENSES = 'voltage';
 	const SENSOR_UNIT = 'Millivolts';
+	const INPUT_PATH_ENV = 'PTS_GPU_VOLTAGE_INPUT_PATH';
 
 	public function read_sensor()
 	{
-		$sensor = -1;
+		$sensor = self::read_voltage_input(pts_env::read(self::INPUT_PATH_ENV));
+
+		if($sensor != -1)
+		{
+			return $sensor;
+		}
 
 		// TODO XXX: Nouveau driver exposes GPU voltage on at least some cards via performance_level
 		if(is_file('/sys/class/drm/card0/device/hwmon/hwmon1/in0_label') && pts_file_io::file_get_contents('/sys/class/drm/card0/device/hwmon/hwmon1/in0_label') == 'vddgfx' && is_file('/sys/class/drm/card0/device/hwmon/hwmon1/in0_input'))
@@ -74,6 +80,17 @@ class gpu_voltage extends phodevi_sensor
 		}
 
 		return $sensor;
+	}
+
+	private static function read_voltage_input($voltage_input_file)
+	{
+		if($voltage_input_file == false || !is_readable($voltage_input_file))
+		{
+			return -1;
+		}
+
+		$voltage = pts_file_io::file_get_contents($voltage_input_file);
+		return is_numeric($voltage) ? $voltage : -1;
 	}
 }
 

--- a/pts-core/objects/pts_env.php
+++ b/pts-core/objects/pts_env.php
@@ -93,6 +93,42 @@ class pts_env
 			'value_type' => 'string',
 			'advertise_in_phoromatic' => true,
 			),
+		'PTS_GPU_FREQ_INPUT_PATH' => array(
+			'description' => 'This option can be used for overriding the Linux sysfs file used for the GPU frequency sensor. Set it to an absolute readable GPU frequency path, such as a gt_cur_freq_mhz or pp_dpm_sclk sysfs file, when the default GPU frequency paths are not detected. The value is expected to report Megahertz or use the active pp_dpm_sclk line format.',
+			'default' => '',
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
+		'PTS_GPU_MEMORY_USAGE_INPUT_PATH' => array(
+			'description' => 'This option can be used for overriding the Linux sysfs file used for the GPU memory usage sensor. Set it to an absolute readable memory usage path, such as /sys/class/drm/card0/device/mem_info_vram_used, when the default GPU memory usage paths are not detected. Values greater than 1000000 are treated as bytes and converted to Megabytes.',
+			'default' => '',
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
+		'PTS_GPU_POWER_INPUT_PATH' => array(
+			'description' => 'This option can be used for overriding the Linux sysfs file used for the GPU power sensor. Set it to an absolute readable hwmon power input path, such as /sys/class/drm/card1/device/hwmon/hwmon4/power1_input, when the default GPU power paths are not detected. The value is expected to report microwatts as Linux hwmon power*_input and power*_average files do.',
+			'default' => '',
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
+		'PTS_GPU_TEMP_INPUT_PATH' => array(
+			'description' => 'This option can be used for overriding the Linux sysfs file used for the GPU temperature sensor. Set it to an absolute readable hwmon temperature input path, such as a temp*_input file, when the default GPU temperature paths are not detected. Values greater than 1000 are treated as millidegrees Celsius and converted to Celsius.',
+			'default' => '',
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
+		'PTS_GPU_USAGE_INPUT_PATH' => array(
+			'description' => 'This option can be used for overriding the Linux sysfs file used for the GPU usage sensor. Set it to an absolute readable GPU usage path, such as /sys/class/drm/card0/device/gpu_busy_percent, when the default GPU usage paths are not detected. The value is expected to report a percentage from 0 to 100.',
+			'default' => '',
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
+		'PTS_GPU_VOLTAGE_INPUT_PATH' => array(
+			'description' => 'This option can be used for overriding the Linux sysfs file used for the GPU voltage sensor. Set it to an absolute readable hwmon voltage input path, such as an in*_input file, when the default GPU voltage paths are not detected. The value is expected to report millivolts.',
+			'default' => '',
+			'usage' => array('all'),
+			'value_type' => 'string',
+			),
 		'TEST_EXECUTION_SORT' => array(
 			'description' => 'This option can be used for controlling the sort order that the test profiles / benchmarks are run in, whether sorted or not and in what manner.',
 			'default' => '',

--- a/pts-core/tests/gpu_sensor_env_path_test.php
+++ b/pts-core/tests/gpu_sensor_env_path_test.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+	Phoronix Test Suite
+	Copyright (C) 2026, Phoronix Media
+	Copyright (C) 2026, Michael Larabel
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+require_once(dirname(__DIR__) . '/objects/pts_env.php');
+require_once(dirname(__DIR__) . '/objects/pts_file_io.php');
+require_once(dirname(__DIR__) . '/objects/pts_math.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/phodevi_sensor.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/sensors/gpu_freq.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/sensors/gpu_memory_usage.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/sensors/gpu_power.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/sensors/gpu_temp.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/sensors/gpu_usage.php');
+require_once(dirname(__DIR__) . '/objects/phodevi/sensors/gpu_voltage.php');
+
+function pts_gpu_sensor_env_path_test_cleanup($test_dir, $env_vars)
+{
+	foreach($env_vars as $env_var)
+	{
+		putenv($env_var);
+	}
+	if($test_dir != false && is_dir($test_dir))
+	{
+		foreach(pts_file_io::glob($test_dir . DIRECTORY_SEPARATOR . '*') as $file)
+		{
+			if(is_file($file))
+			{
+				unlink($file);
+			}
+		}
+		rmdir($test_dir);
+	}
+}
+
+function pts_gpu_sensor_env_path_test_fail($message, $test_dir, $env_vars)
+{
+	pts_gpu_sensor_env_path_test_cleanup($test_dir, $env_vars);
+	echo 'gpu_sensor_env_path_test failed: ' . $message . PHP_EOL;
+	exit(1);
+}
+
+$env_vars = array(
+	'PTS_GPU_FREQ_INPUT_PATH',
+	'PTS_GPU_MEMORY_USAGE_INPUT_PATH',
+	'PTS_GPU_POWER_INPUT_PATH',
+	'PTS_GPU_TEMP_INPUT_PATH',
+	'PTS_GPU_USAGE_INPUT_PATH',
+	'PTS_GPU_VOLTAGE_INPUT_PATH',
+	);
+
+$test_dir = tempnam(sys_get_temp_dir(), 'pts-gpu-sensors-');
+if($test_dir == false || !unlink($test_dir) || !mkdir($test_dir))
+{
+	pts_gpu_sensor_env_path_test_fail('unable to create temporary directory', $test_dir, $env_vars);
+}
+
+$files = array(
+	'freq' => '0: 300Mhz' . PHP_EOL . '1: 1234Mhz *' . PHP_EOL,
+	'memory' => '256000000' . PHP_EOL,
+	'power' => '10000000' . PHP_EOL,
+	'temp' => '47500' . PHP_EOL,
+	'usage' => '73' . PHP_EOL,
+	'voltage' => '950' . PHP_EOL,
+	);
+
+foreach($files as $name => $contents)
+{
+	if(file_put_contents($test_dir . DIRECTORY_SEPARATOR . $name, $contents) === false)
+	{
+		pts_gpu_sensor_env_path_test_fail('unable to create synthetic ' . $name . ' input', $test_dir, $env_vars);
+	}
+}
+
+putenv('PTS_GPU_FREQ_INPUT_PATH=' . $test_dir . DIRECTORY_SEPARATOR . 'freq');
+putenv('PTS_GPU_MEMORY_USAGE_INPUT_PATH=' . $test_dir . DIRECTORY_SEPARATOR . 'memory');
+putenv('PTS_GPU_POWER_INPUT_PATH=' . $test_dir . DIRECTORY_SEPARATOR . 'power');
+putenv('PTS_GPU_TEMP_INPUT_PATH=' . $test_dir . DIRECTORY_SEPARATOR . 'temp');
+putenv('PTS_GPU_USAGE_INPUT_PATH=' . $test_dir . DIRECTORY_SEPARATOR . 'usage');
+putenv('PTS_GPU_VOLTAGE_INPUT_PATH=' . $test_dir . DIRECTORY_SEPARATOR . 'voltage');
+
+$checks = array(
+	'gpu.freq' => array(new gpu_freq(0, null), 1234, 'Megahertz'),
+	'gpu.memory-usage' => array(new gpu_memory_usage(0, null), 256, 'Megabytes'),
+	'gpu.power' => array(new gpu_power(0, null), 10, 'Watts'),
+	'gpu.temp' => array(new gpu_temp(0, null), 47.5, 'Celsius'),
+	'gpu.usage' => array(new gpu_usage(0, null), 73, 'Percent'),
+	'gpu.voltage' => array(new gpu_voltage(0, null), 950, 'Millivolts'),
+	);
+
+foreach($checks as $name => $check)
+{
+	list($sensor, $expected_value, $expected_unit) = $check;
+	$value = $sensor->read_sensor();
+
+	if($value != $expected_value)
+	{
+		pts_gpu_sensor_env_path_test_fail($name . ' expected ' . $expected_value . ' but read ' . $value, $test_dir, $env_vars);
+	}
+	if($sensor->get_unit() != $expected_unit)
+	{
+		pts_gpu_sensor_env_path_test_fail($name . ' expected unit ' . $expected_unit . ' but read ' . $sensor->get_unit(), $test_dir, $env_vars);
+	}
+	if(!$sensor->support_check())
+	{
+		pts_gpu_sensor_env_path_test_fail($name . ' expected support_check() to pass with override path', $test_dir, $env_vars);
+	}
+}
+
+pts_gpu_sensor_env_path_test_cleanup($test_dir, $env_vars);
+echo 'gpu_sensor_env_path_test passed' . PHP_EOL;
+
+?>


### PR DESCRIPTION
Fixes #754
This adds optional `PTS_GPU_*_INPUT_PATH` environment variables for overriding GPU sensor sysfs paths when the default discovery logic misses a valid device path.

Covered sensors:
- `gpu.power`
- `gpu.temp`
- `gpu.usage`
- `gpu.voltage`
- `gpu.freq`
- `gpu.memory-usage`

Also adds documentation for the new environment variables and a small regression test that verifies the overrides participate in sensor support detection and value/unit conversion.