### PR TITLE
Update tinyxml package name in brew-packages.xml

### DIFF
--- a/pts-core/external-test-dependencies/xml/brew-packages.xml
+++ b/pts-core/external-test-dependencies/xml/brew-packages.xml
@@ -223,7 +223,7 @@
 		</Package>
 		<Package>
 			<GenericName>tinyxml</GenericName>
-			<PackageName>libtinyxml tinyxml2</PackageName>
+			<PackageName>tinyxml2</PackageName>
 		</Package>
 		<Package>
 			<GenericName>opencl</GenericName>


### PR DESCRIPTION
There is no "libtinyxml" package in Homebrew any more.